### PR TITLE
feat(meeting): implement WebSocket client connection hook

### DIFF
--- a/.github/plans/WM-2.md
+++ b/.github/plans/WM-2.md
@@ -1,0 +1,142 @@
+# WM-2: Implement WebSocket Client Connection for Meeting Room
+
+---
+
+## 1. Feature Summary
+
+This feature establishes the lifecycle-managed Socket.IO client connection for the meeting room page. When a user enters /meetings/:id, the frontend automatically connects to the signaling server with JWT authentication, emits a join-room event, and cleanly disconnects when the user leaves the page.
+
+---
+
+## 2. Problem Statement
+
+The meeting experience requires real-time signaling to support participant presence and future WebRTC negotiation. Currently the frontend has no WebSocket connection layer. This issue builds the connection foundation so that subsequent issues (presence events, WebRTC offer/answer) can be layered on top.
+
+---
+
+## 3. Feature Type
+
+**Feature Type:** Frontend
+
+The issue exclusively concerns client-side socket lifecycle management: installing socket.io-client, creating a custom hook, and wiring it into the existing MeetingLobbyPage. No backend work is in scope (the NestJS gateway is a separate dependency).
+
+---
+
+## 4. Technical Design
+
+### Frontend
+
+**Pages / routes to modify:**
+- src/features/meeting/components/meetingLobbyPage.tsx -- integrate useMeetingSocket hook; show inline error notice if connection fails.
+
+**New files:**
+- src/features/meeting/hooks/useMeetingSocket.ts -- custom hook managing the full socket lifecycle.
+- src/features/meeting/hooks/index.ts -- barrel export.
+
+**Files to update:**
+- src/config/env.ts -- add socketUrl: import.meta.env.VITE_SOCKET_URL.
+- src/features/meeting/index.ts -- export useMeetingSocket.
+- src/features/meeting/types/meeting.types.ts -- add SocketConnectionStatus type and UseMeetingSocketReturn interface.
+- .env -- add VITE_SOCKET_URL variable.
+
+**Hook design -- useMeetingSocket(meetingId: string | undefined):**
+
+Returns: { isConnected: boolean, connectionStatus: SocketConnectionStatus, error: string | null }
+
+Lifecycle:
+1. On mount (when meetingId and accessToken are both defined): create a Socket.IO instance with autoConnect: false and { auth: { token: accessToken } }. Connect immediately.
+2. On connect event: emit join-room with { meetingId }. Set connectionStatus to connected.
+3. On connect_error event: set error state; set connectionStatus to error.
+4. On disconnect event: set connectionStatus to disconnected.
+5. On cleanup (unmount): call socket.disconnect() and reset local state.
+
+The socket instance is held in a useRef -- it must NOT be in useState to avoid re-renders on internal socket updates.
+
+**Component integration -- MeetingLobbyPage:**
+- Call useMeetingSocket(id) where id comes from useParams.
+- If connectionStatus === error, render a non-blocking inline notice using existing AlertTriangleIcon + Text pattern.
+- Do not block the lobby UI on socket state.
+
+### State Management
+
+- useMeetingSocket manages its own isConnected, connectionStatus, and error state internally via useState.
+- No Zustand store or React Query cache needed -- connection state is local to the meeting page lifetime.
+- The socket useRef keeps the instance stable across renders without being part of React state.
+
+### Realtime / External Services
+
+- Library: socket.io-client (production dependency, not yet installed).
+- Server URL: read from env.socketUrl (VITE_SOCKET_URL).
+- Auth: passed as { auth: { token: accessToken } } in Socket.IO client options.
+- Events emitted client -> server: join-room with payload { meetingId: string }.
+- Events received: none in scope for this issue.
+
+---
+
+## 5. Edge Cases
+
+- **accessToken null at mount** -- do not connect; log warning. Unlikely behind ProtectedRoute but guarded anyway.
+- **meetingId undefined** -- do not connect. MeetingLobbyPage already redirects in this case.
+- **connect_error** -- set connectionStatus to error; show inline notice to the user; do not crash or force a redirect.
+- **Unmount before connect completes** -- socket.disconnect() is safe to call even if the socket has not fully connected yet.
+- **VITE_SOCKET_URL not set** -- guard env.socketUrl for falsiness; log a warning and return early without throwing.
+- **Token refresh mid-session** -- socket auth is embedded at handshake time; token rotation mid-session is out of scope for this issue.
+- **Duplicate connections** -- useRef holding the socket + a single useEffect with [meetingId, accessToken] deps prevents duplicate sockets.
+
+---
+
+## 6. Implementation Plan
+
+1. **Install socket.io-client** -- run: pnpm add socket.io-client
+2. **Extend env config** -- add socketUrl: import.meta.env.VITE_SOCKET_URL to src/config/env.ts; add VITE_SOCKET_URL entry to .env.
+3. **Add socket types** -- add SocketConnectionStatus union (idle | connecting | connected | error | disconnected) and UseMeetingSocketReturn interface to meeting.types.ts.
+4. **Implement useMeetingSocket** -- src/features/meeting/hooks/useMeetingSocket.ts. Guard falsy inputs. Hold socket in useRef. In useEffect: create socket, register event listeners, call socket.connect(). On connect: emit join-room. Cleanup: removeAllListeners() + disconnect().
+5. **Barrel export** -- create src/features/meeting/hooks/index.ts exporting useMeetingSocket.
+6. **Update feature barrel** -- add export for useMeetingSocket to src/features/meeting/index.ts.
+7. **Integrate into MeetingLobbyPage** -- call useMeetingSocket(id); render conditional inline error notice when connectionStatus is error.
+8. **Add i18n key** -- add "socketError": "Could not connect to the meeting room. Please refresh." under meeting.lobby in src/lib/i18n/locales/en.json.
+9. **Lint and type-check** -- run pnpm lint && pnpm type-check; fix all errors before marking complete.
+
+---
+
+## 7. Implementation Order
+
+1. Install socket.io-client: pnpm add socket.io-client
+2. Extend src/config/env.ts with socketUrl; add VITE_SOCKET_URL to .env
+3. Add SocketConnectionStatus union type and UseMeetingSocketReturn interface to meeting.types.ts
+4. Implement src/features/meeting/hooks/useMeetingSocket.ts
+5. Create src/features/meeting/hooks/index.ts barrel
+6. Update src/features/meeting/index.ts to export useMeetingSocket
+7. Integrate useMeetingSocket(id) into MeetingLobbyPage; add inline error notice
+8. Add meeting.lobby.socketError key to src/lib/i18n/locales/en.json
+9. Run pnpm lint and pnpm type-check; resolve all errors
+
+---
+
+## 8. Task Breakdown
+
+**Frontend**
+
+- [ ] Run pnpm add socket.io-client
+- [ ] Add socketUrl: import.meta.env.VITE_SOCKET_URL to src/config/env.ts
+- [ ] Add VITE_SOCKET_URL=<signaling-server-url> to .env
+- [ ] Add SocketConnectionStatus union type to src/features/meeting/types/meeting.types.ts
+- [ ] Add UseMeetingSocketReturn interface to src/features/meeting/types/meeting.types.ts
+- [ ] Create src/features/meeting/hooks/useMeetingSocket.ts with full socket lifecycle
+- [ ] Create src/features/meeting/hooks/index.ts barrel export
+- [ ] Export useMeetingSocket from src/features/meeting/index.ts
+- [ ] Call useMeetingSocket(id) in MeetingLobbyPage
+- [ ] Render inline socket error notice when connectionStatus === error
+- [ ] Add meeting.lobby.socketError key to src/lib/i18n/locales/en.json
+
+**Shared / Cross-cutting**
+
+- [ ] Document VITE_SOCKET_URL in .env.example if the file exists
+
+**Testing**
+
+- [ ] Hook test: connects when meetingId and accessToken are both defined
+- [ ] Hook test: emits join-room with correct meetingId on the connect event
+- [ ] Hook test: calls socket.disconnect() on unmount (cleanup)
+- [ ] Hook test: sets connectionStatus to error on connect_error event
+- [ ] Hook test: does not connect when meetingId is undefined

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.4",
     "react-router-dom": "^7.12.0",
+    "socket.io-client": "^4.8.3",
     "vite-plugin-svgr": "^4.5.0",
     "zustand": "^5.0.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-router-dom:
         specifier: ^7.12.0
         version: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
       vite-plugin-svgr:
         specifier: ^4.5.0
         version: 4.5.0(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(yaml@2.8.2))
@@ -663,6 +666,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -1111,6 +1117,13 @@ packages:
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -1773,6 +1786,14 @@ packages:
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.5:
+    resolution: {integrity: sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==}
+    engines: {node: '>=10.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1922,6 +1943,22 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2379,6 +2416,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.55.1':
     optional: true
+
+  '@socket.io/component-emitter@3.1.2': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.6)':
     dependencies:
@@ -2839,6 +2878,20 @@ snapshots:
   electron-to-chromium@1.5.267: {}
 
   emoji-regex@10.6.0: {}
+
+  engine.io-client@6.6.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -3470,6 +3523,24 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.8.1
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.5
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.5:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   source-map-js@1.2.1: {}
 
   string-argv@0.3.2: {}
@@ -3589,6 +3660,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
+
+  ws@8.18.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   yallist@3.1.1: {}
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,4 @@
 export const env = {
   apiBaseUrl: import.meta.env.VITE_API_BASE_URL,
+  socketUrl: import.meta.env.VITE_WS_URL,
 } as const;

--- a/src/features/meeting/components/meetingLobbyPage.tsx
+++ b/src/features/meeting/components/meetingLobbyPage.tsx
@@ -9,6 +9,8 @@ import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg?react';
 import CopyIcon from '@/assets/icons/copy.svg?react';
 import SpinnerIcon from '@/assets/icons/spinner.svg?react';
 import { meetingsApi } from '../services/meetingService';
+import { useMeetingSocket } from '../hooks';
+import { SOCKET_STATUS } from '../types/meeting.types';
 import type { MeetingLobbyData, ApiError } from '../types/meeting.types';
 
 export const MeetingLobbyPage = () => {
@@ -18,6 +20,8 @@ export const MeetingLobbyPage = () => {
   const { user } = useAuth();
   // Use primitive userId as effect dependency to avoid re-fetching on object reference changes (rerender-dependencies)
   const userId = user?.id;
+
+  const { connectionStatus, error: socketError } = useMeetingSocket(id);
 
   const [lobbyData, setLobbyData] = useState<MeetingLobbyData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -124,6 +128,14 @@ export const MeetingLobbyPage = () => {
       </Header>
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {connectionStatus === SOCKET_STATUS.ERROR && (
+          <div className="mb-4 flex items-center gap-3 rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3">
+            <AlertTriangleIcon className="h-5 w-5 shrink-0 text-yellow-600" />
+            <Text className="text-sm text-yellow-800">
+              {socketError || t('meeting.lobby.socketError')}
+            </Text>
+          </div>
+        )}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 space-y-6">
             <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">

--- a/src/features/meeting/components/meetingLobbyPage.tsx
+++ b/src/features/meeting/components/meetingLobbyPage.tsx
@@ -47,14 +47,18 @@ export const MeetingLobbyPage = () => {
       });
     } catch (err) {
       const apiError = err as ApiError;
+      const statusMessageMap: Record<number, string> = {
+        404: t('meeting.lobby.errorNotFound'),
+        401: t('meeting.lobby.errorUnauthorized'),
+        403: t('meeting.lobby.errorUnauthorized'),
+      };
 
-      if (apiError.statusCode === 404) {
-        setError(t('meeting.lobby.errorNotFound'));
-      } else if (apiError.statusCode === 401 || apiError.statusCode === 403) {
-        setError(t('meeting.lobby.errorUnauthorized'));
-      } else {
-        setError(apiError.message);
-      }
+      const errorMsg =
+        statusMessageMap[apiError.statusCode] ??
+        apiError.message ??
+        t('meeting.lobby.errorDefault');
+
+      setError(errorMsg);
     } finally {
       setIsLoading(false);
     }
@@ -72,6 +76,7 @@ export const MeetingLobbyPage = () => {
   const copyMeetingId = () => {
     if (!id) return;
     navigator.clipboard.writeText(id);
+    // TODO: Show tooltip or toast notification on successful copy
   };
 
   if (isLoading) {

--- a/src/features/meeting/hooks/index.ts
+++ b/src/features/meeting/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useMeetingSocket } from './useMeetingSocket';

--- a/src/features/meeting/hooks/useMeetingSocket.ts
+++ b/src/features/meeting/hooks/useMeetingSocket.ts
@@ -1,0 +1,74 @@
+import { useState, useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+import { useAuth } from '@/features/auth';
+import { env } from '@/config';
+import { SOCKET_STATUS } from '../types/meeting.types';
+import type { SocketConnectionStatus, UseMeetingSocketReturn } from '../types/meeting.types';
+
+export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocketReturn => {
+  const { accessToken } = useAuth();
+  const socketRef = useRef<Socket | null>(null);
+
+  const [connectionStatus, setConnectionStatus] = useState<SocketConnectionStatus>(
+    SOCKET_STATUS.IDLE,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!meetingId) {
+      return;
+    }
+
+    if (!accessToken) {
+      console.warn('[useMeetingSocket] accessToken is null — skipping connection');
+      return;
+    }
+
+    if (!env.socketUrl) {
+      console.warn('[useMeetingSocket] VITE_WS_URL is not set — skipping connection');
+      return;
+    }
+
+    const socket = io(env.socketUrl, {
+      autoConnect: false,
+      auth: { token: accessToken },
+    });
+
+    socketRef.current = socket;
+
+    const handleConnect = () => {
+      setConnectionStatus(SOCKET_STATUS.CONNECTED);
+      setError(null);
+      socket.emit('join-room', { meetingId });
+    };
+
+    const handleConnectError = (err: Error) => {
+      setConnectionStatus(SOCKET_STATUS.ERROR);
+      setError(err.message);
+    };
+
+    const handleDisconnect = () => {
+      setConnectionStatus(SOCKET_STATUS.DISCONNECTED);
+    };
+
+    socket.on('connect', handleConnect);
+    socket.on('connect_error', handleConnectError);
+    socket.on('disconnect', handleDisconnect);
+
+    socket.connect();
+
+    return () => {
+      socket.removeAllListeners();
+      socket.disconnect();
+      socketRef.current = null;
+      setConnectionStatus(SOCKET_STATUS.IDLE);
+      setError(null);
+    };
+  }, [meetingId, accessToken]);
+
+  return {
+    isConnected: connectionStatus === SOCKET_STATUS.CONNECTED,
+    connectionStatus,
+    error,
+  };
+};

--- a/src/features/meeting/index.ts
+++ b/src/features/meeting/index.ts
@@ -2,6 +2,9 @@ export { StartMeetingPage } from './components/startMeetingPage';
 export { MeetingLobbyPage } from './components/meetingLobbyPage';
 
 export { meetingsApi } from './services/meetingService';
+export { useMeetingSocket } from './hooks';
+
+export { SOCKET_STATUS } from './types/meeting.types';
 
 export type {
   Meeting,
@@ -11,4 +14,6 @@ export type {
   GetMeetingResponse,
   MeetingLobbyData,
   ApiError,
+  SocketConnectionStatus,
+  UseMeetingSocketReturn,
 } from './types/meeting.types';

--- a/src/features/meeting/types/meeting.types.ts
+++ b/src/features/meeting/types/meeting.types.ts
@@ -49,3 +49,20 @@ export interface ApiError {
   code: string;
   statusCode: number;
 }
+
+// Socket types
+export const SOCKET_STATUS = {
+  IDLE: 'idle',
+  CONNECTING: 'connecting',
+  CONNECTED: 'connected',
+  ERROR: 'error',
+  DISCONNECTED: 'disconnected',
+} as const;
+
+export type SocketConnectionStatus = (typeof SOCKET_STATUS)[keyof typeof SOCKET_STATUS];
+
+export interface UseMeetingSocketReturn {
+  isConnected: boolean;
+  connectionStatus: SocketConnectionStatus;
+  error: string | null;
+}

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -97,7 +97,8 @@
       "participantsEmpty": "No participants yet",
       "youLabel": "(You)",
       "errorNotFound": "Meeting not found",
-      "errorUnauthorized": "You are not authorized to access this meeting"
+      "errorUnauthorized": "You are not authorized to access this meeting",
+      "socketError": "Could not connect to the meeting room. Please refresh."
     },
     "role": {
       "host": "Host",


### PR DESCRIPTION
## References
- #5

## Description
- Added useMeetingSocket hook with full Socket.IO lifecycle management
- Added SOCKET_STATUS constant to eliminate status string literals
- Installed socket.io-client dependency
- Extended env config with socketUrl (VITE_WS_URL)
- Integrated hook into MeetingLobbyPage with inline error notice
- Added meeting.lobby.socketError i18n key
- Added WM-2 implementation plan

## Test plan
- [x] Opening meeting page establishes WebSocket connection visible in DevTools WS tab
- [x] join-room emitted with correct meetingId on connect
- [x] Navigating away disconnects socket cleanly
- [x] Connection failure shows inline error banner without crashing
- [x] Re-renders do not create duplicate socket instances
