### PR TITLE
feat(meeting): add realtime participant list

### DIFF
--- a/.github/plans/WM-3.md
+++ b/.github/plans/WM-3.md
@@ -1,0 +1,174 @@
+# WM-3: Implement Realtime Participant List in Meeting Room
+
+---
+
+## 1. Feature Summary
+
+This feature adds a live participant list to the meeting room page. When users join or leave while the page is open, the list updates immediately via WebSocket events (user-joined, user-left) without a page reload. The initial list is seeded from the REST meeting data already fetched on page load.
+
+---
+
+## 2. Problem Statement
+
+The meeting lobby currently shows a static participant list drawn from the initial REST response (meeting.members). Participants who join or leave after page load are invisible until the user refreshes. This blocks the core real-time meeting experience. This issue replaces the static inline rendering with a live, event-driven participant list powered by the socket connection established in WM-2.
+
+---
+
+## 3. Feature Type
+
+**Feature Type:** Frontend
+
+All work is client-side: listening to WebSocket events emitted by the backend gateway, managing participant state in a new hook, and extracting the participant rendering into a reusable ParticipantList component. No API endpoints or backend code are modified.
+
+---
+
+## 4. Technical Design
+
+### Frontend
+
+**Files to create:**
+- src/features/meeting/hooks/useParticipants.ts -- custom hook that registers user-joined, user-left, and room-state listeners on the socket and maintains participant state.
+- src/features/meeting/components/ParticipantList.tsx -- standalone component rendering the participant list with loading, empty, and populated states.
+
+**Files to modify:**
+- src/features/meeting/hooks/useMeetingSocket.ts -- add socket: Socket|null to the return value.
+- src/features/meeting/types/meeting.types.ts -- add ParticipantJoinedPayload, ParticipantLeftPayload, RoomStatePayload, UseParticipantsReturn types; extend UseMeetingSocketReturn.
+- src/features/meeting/components/meetingLobbyPage.tsx -- replace inline participant rendering with ParticipantList; wire in useParticipants.
+- src/features/meeting/hooks/index.ts -- export useParticipants.
+- src/features/meeting/index.ts -- export useParticipants and ParticipantList.
+- src/lib/i18n/locales/en.json -- add meeting.lobby.participantsLoading key.
+
+**Component: ParticipantList**
+
+Props interface:
+  participants: MeetingMember[]
+  currentUserId: string | undefined
+  isSocketConnected: boolean
+
+States to render:
+- Loading / not connected: show a subtle spinner or connecting text row.
+- Empty: connected but no participants -- show t(meeting.lobby.participantsEmpty).
+- Populated: render each participant row with avatar initial, display name, (You) badge, and host badge, reusing the existing row layout from meetingLobbyPage.tsx.
+
+The component must be a pure display component -- no socket or hook logic inside it.
+
+**Component hierarchy in MeetingLobbyPage:**
+MeetingLobbyPage
+  div lg:col-span-1
+    ParticipantList
+      (loading state row)
+      (empty state text)
+      participant rows
+        avatar initial div
+        display name + (You) badge
+        host badge (conditional)
+
+**UI interactions:**
+- Participant rows appear/disappear immediately when socket events fire.
+- If the socket disconnects after initial connection, the last known participant list remains visible (not cleared).
+
+### State Management
+
+**useParticipants(socket, initialMembers, currentUserId):**
+
+- Accepts the socket instance returned by the extended useMeetingSocket hook.
+- Seeds participants state with initialMembers (the meeting.members array from the REST response) when the effect runs.
+- Listens for user-joined: if a participant with that userId is not already in the list, append a MeetingMember-shaped entry built from the payload.
+- Listens for user-left: filter out the participant matching userId.
+- Listens for room-state (optional): if the backend sends a full participant list, replace the current state with the received list.
+- Cleans up all event listeners in the useEffect return.
+- Returns { participants: MeetingMember[], participantCount: number }.
+
+State is local to the hook using useState. No Zustand store is introduced because: (a) no Zustand stores exist in the repo yet, (b) participant state is scoped to the meeting page lifetime, and (c) the existing pattern (useMeetingSocket, authContext) uses local state and React Context.
+
+**UseMeetingSocketReturn extension:**
+
+Add socket: Socket|null to the existing interface. Expose it via a useState in useMeetingSocket that is set to the socket instance on connect and reset to null on cleanup, ensuring consumers re-render when the socket becomes available.
+
+### Realtime / External Services
+
+Events consumed from server (no new events emitted by this feature):
+
+| Event | Direction | Payload | When |
+| --- | --- | --- | --- |
+| user-joined | server to client | { userId, displayName } | Another participant joins the room |
+| user-left | server to client | { userId } | A participant leaves the room |
+| room-state | server to client | { members: [{ userId, displayName }] } | After join-room is emitted (optional, confirm with backend) |
+
+Confirm the exact payload shapes with the backend gateway owner before implementing. Types in meeting.types.ts must match actual server payloads.
+
+---
+
+## 7. Edge Cases
+
+- **Duplicate user-joined events:** Guard with a userId-based existence check before appending -- do not add the same participant twice.
+- **user-left for unknown userId:** No-op silently -- the userId is simply not found in the list.
+- **Socket not connected on page load:** Display the static REST-seeded list; realtime updates begin once the socket connects. Do not block rendering on socket state.
+- **Socket disconnects mid-session:** Keep the last known participant list visible -- do not clear it. The existing connectionStatus ERROR banner covers the connection loss notice.
+- **room-state received before REST data:** Handle by initialising with an empty array and replacing state when room-state fires.
+- **waitingmeetingId changes while mounted:** useParticipants effect must reset on socket change (socket becomes null on cleanup, then a new socket is provided).
+- **user-left fires for the current user:** Remove them from the list gracefully; page navigation on deliberate leave is handled separately.
+- **user-joined payload missing displayName:** Fall back to a placeholder string such as Unknown User rather than crashing.
+
+---
+
+## 8. Implementation Plan
+
+1. **Add new TypeScript types** to meeting.types.ts: ParticipantJoinedPayload, ParticipantLeftPayload, RoomStatePayload, UseParticipantsReturn. Also add socket: Socket|null to UseMeetingSocketReturn.
+2. **Extend useMeetingSocket** to return the socket instance. Add a socketState useState that is set to the socket instance after it is created and reset to null in the cleanup return. Return it as socket in UseMeetingSocketReturn.
+3. **Implement useParticipants** in src/features/meeting/hooks/useParticipants.ts. Accept socket (Socket|null), initialMembers (MeetingMember[]), and currentUserId (string|undefined). In a useEffect keyed on socket: seed state from initialMembers, register user-joined (dedup by userId), user-left (filter by userId), and room-state (replace list) listeners. Return { participants, participantCount }.
+4. **Update hooks/index.ts** to export useParticipants.
+5. **Create ParticipantList.tsx** in src/features/meeting/components/. Extract the existing participant row JSX from meetingLobbyPage.tsx into this component. Add the loading state (when isSocketConnected is false, show a connecting indicator). Keep it a pure display component.
+6. **Refactor meetingLobbyPage.tsx**: destructure socket from useMeetingSocket(id). Call useParticipants(socket, lobbyData?.meeting.members ?? [], userId). Replace the inline participant block with ParticipantList. Update the participant count heading to use participantCount from useParticipants.
+7. **Update src/features/meeting/index.ts** to export useParticipants and ParticipantList.
+8. **Add i18n key** participantsLoading: Connecting... under meeting.lobby in en.json.
+9. **Run pnpm lint and pnpm type-check** and fix all errors.
+
+---
+
+## 9. Implementation Order
+
+1. Add ParticipantJoinedPayload, ParticipantLeftPayload, RoomStatePayload, UseParticipantsReturn types; extend UseMeetingSocketReturn with socket field
+2. Extend useMeetingSocket to expose the socket instance in its return value
+3. Implement src/features/meeting/hooks/useParticipants.ts
+4. Update src/features/meeting/hooks/index.ts to export useParticipants
+5. Create src/features/meeting/components/ParticipantList.tsx
+6. Refactor meetingLobbyPage.tsx to use useParticipants and ParticipantList
+7. Update src/features/meeting/index.ts to export useParticipants and ParticipantList
+8. Add meeting.lobby.participantsLoading key to src/lib/i18n/locales/en.json
+9. Run pnpm lint and pnpm type-check; fix all errors
+
+---
+
+## 10. Task Breakdown
+
+**Frontend**
+
+- [ ] Add ParticipantJoinedPayload type to meeting.types.ts
+- [ ] Add ParticipantLeftPayload type to meeting.types.ts
+- [ ] Add RoomStatePayload type to meeting.types.ts
+- [ ] Add UseParticipantsReturn interface to meeting.types.ts
+- [ ] Add socket: Socket|null field to UseMeetingSocketReturn in meeting.types.ts
+- [ ] Extend useMeetingSocket to track and return the active socket instance
+- [ ] Create src/features/meeting/hooks/useParticipants.ts
+- [ ] Export useParticipants from src/features/meeting/hooks/index.ts
+- [ ] Create src/features/meeting/components/ParticipantList.tsx
+- [ ] Replace inline participant block in meetingLobbyPage.tsx with ParticipantList
+- [ ] Wire useParticipants(socket, initialMembers, userId) into meetingLobbyPage.tsx
+- [ ] Update participant count heading to use participantCount from useParticipants
+- [ ] Export useParticipants and ParticipantList from src/features/meeting/index.ts
+- [ ] Add participantsLoading: Connecting... to meeting.lobby in en.json
+
+**Testing**
+
+- [ ] Hook test: seeds participant list from initialMembers on mount
+- [ ] Hook test: appends participant on user-joined event
+- [ ] Hook test: ignores duplicate user-joined for same userId
+- [ ] Hook test: removes participant on user-left event
+- [ ] Hook test: no-ops on user-left for unknown userId
+- [ ] Hook test: replaces list on room-state event
+- [ ] Hook test: removes all event listeners on unmount
+- [ ] Component test: renders one row per participant
+- [ ] Component test: shows loading state when isSocketConnected is false
+- [ ] Component test: shows empty state when connected and participants is empty
+- [ ] Component test: marks the current user row with (You) badge

--- a/.github/prompts/implement-feature.prompt.md
+++ b/.github/prompts/implement-feature.prompt.md
@@ -11,6 +11,44 @@ argument-hint: <issue number>
 
 # Implement Feature
 
+## Backend API Source of Truth
+
+The backend API contract is defined in the backend repository documentation.
+
+**Location:** `../we-meet-server/docs/`
+
+These documents define:
+
+- REST endpoints (method, path, request/response shape)
+- Request payloads and response payloads
+- Authentication requirements per endpoint
+- WebSocket events, event names, and payload shapes _(if applicable)_
+
+The backend documentation is the **single source of truth** for all API contracts. The agent must never invent endpoints, payload fields, or response structures. If a document cannot be found, re-search `../we-meet-server/docs/` before making any assumption.
+
+---
+
+## API Layer Rule
+
+All API calls must be implemented in the API service layer:
+
+```
+src/features/<feature>/services/<feature>.service.ts
+```
+
+Or, for shared/cross-feature calls:
+
+```
+src/api/
+├── meetings.api.ts
+├── auth.api.ts
+└── ...
+```
+
+**Components must never call backend endpoints directly.** They must use functions exported from the service or API layer.
+
+---
+
 ## Input
 
 The GitHub issue to implement: `${input:issue:Provide the issue number (e.g. 42)}`
@@ -20,6 +58,31 @@ The GitHub issue to implement: `${input:issue:Provide the issue number (e.g. 42)
 ## Steps
 
 Follow every step in order. Do not skip any step.
+
+### Step 0 — Read backend API documentation
+
+**Run this step before implementing any feature that interacts with the backend (REST API or WebSocket). Skip only if the plan is confirmed as frontend-only with zero backend API calls.**
+
+1. Explore the backend docs folder:
+
+   ```bash
+   ls ../we-meet-server/docs/
+   ```
+
+2. Search for documentation files relevant to the feature (by resource name, route path, or event name from the issue title/description).
+
+3. Read the relevant files and extract:
+   - **HTTP method** and **endpoint path** for each endpoint
+   - **Request payload** — field names, types, required vs optional
+   - **Response payload** — shape, field names, types
+   - **Authentication requirements** — Bearer token, roles, guards
+   - **WebSocket events** — event names and payload shapes _(if applicable)_
+
+4. Retain this information. It supersedes anything in the plan file's API Contract section if there is a conflict — the live backend docs are always authoritative.
+
+> Never guess API contracts. If documentation is missing or unclear, note it explicitly in the Step 7 follow-up report.
+
+---
 
 ### Step 1 — Read the issue
 
@@ -74,10 +137,11 @@ Search for and read based on the **Feature Type** from the plan.
 - Shared UI components () and design system usage
 - Shared layout components ()
 - State management hooks (React Query, Zustand, Context)
-- API client wrappers and service layers (, )
+- API client wrappers and service layers (`src/features/*/services/`, `src/api/`)
 - Form handling and validation patterns
 - Error and loading state patterns in existing pages
 - Existing hooks and reusable utilities
+- The existing API service pattern to understand how endpoints are called and how errors are handled
 
 **For Backend and Full-Stack features:**
 
@@ -96,13 +160,22 @@ Use this context to ensure every new file and change is consistent with the exis
 
 Implement tasks **strictly following the implementation order from the plan file**. Complete each task from the checklist sequentially before moving to the next.
 
-Rules:
+**API implementation rules** _(apply to every API call, regardless of Feature Type)_:
+
+- Always use the endpoint paths, request fields, response shapes, and WebSocket event names read from `../we-meet-server/docs/` in Step 0 — never guess or invent them
+- Match request body field names and types **exactly** as documented
+- Match response structure **exactly** — do not assume fields not present in the docs
+- Place all API call implementations in `src/features/<feature>/services/` or `src/api/` — never inside components or hooks directly
+- Components must consume API functions exported from the service layer; never call `fetch`/`axios` directly inside a component
+
+**General rules:**
 
 - Follow existing file naming conventions (e.g. `feature.service.ts`, `useFeature.ts`, `FeaturePage.tsx`)
 - Reuse existing shared UI components, hooks, and utilities — do not reinvent them
 - Follow the existing API service pattern in `src/features/*/services/`
 - Follow the existing error and loading state patterns found in the codebase
 - Follow the existing i18n pattern for all user-facing strings
+- Follow existing folder structure conventions; do not introduce new architectural patterns unless the plan explicitly requires it
 - Do not modify files unrelated to the feature
 - Do not remove or alter existing functionality
 - Do not implement anything not in the plan
@@ -160,7 +233,7 @@ When the implementation is complete and lint and tests pass, report the followin
 - **Files modified** — list every existing file changed
 - **Implementation summary** — a brief description of what was implemented
 - **Deviations** — any deviations from the plan that were required by existing codebase constraints, with justification
-- **Follow-up tasks** — any known gaps, deferred decisions, or next steps
+- **Follow-up tasks** — any known gaps, deferred decisions, or next steps; explicitly note any API contracts that were missing or unclear in `../we-meet-server/docs/`
 
 **Do NOT perform any Git operations:**
 
@@ -175,10 +248,13 @@ When the implementation is complete and lint and tests pass, report the followin
 ## Constraints
 
 - The **plan file is the primary source of truth** for implementation tasks. Do not implement features based on assumptions or the issue alone.
+- The **backend documentation** at `../we-meet-server/docs/` is the single source of truth for all API contracts. It supersedes the plan file if they conflict.
+- **Always read `../we-meet-server/docs/` before writing any API call** — never invent endpoint paths, request fields, response shapes, or WebSocket event names.
+- **All API calls must live in the service/API layer** (`src/features/*/services/` or `src/api/`). Components must not call backend endpoints directly.
 - Do not implement anything not present in the plan file.
 - The **Feature Type** from the plan determines which layers to implement — never implement backend code for a Frontend feature or vice versa.
 - For Full-Stack features, always complete backend layers before starting frontend integration.
-- When the plan includes an **API Contract**, implement every endpoint and event exactly as defined — do not invent or omit any.
+- When the plan includes an **API Contract**, cross-reference it against `../we-meet-server/docs/` and use the backend docs as the final authority.
 - When the plan includes a **UI Architecture**, use the component tree as the basis for implementation — do not copy code from design tools.
 - Do not introduce new architectural patterns unless the plan explicitly requires it.
 - Do not modify files unrelated to the feature.

--- a/src/features/auth/types/auth.types.ts
+++ b/src/features/auth/types/auth.types.ts
@@ -2,6 +2,9 @@ export interface User {
   id: string;
   email: string;
   name: string;
+  role: string;
+  createdAt: string;
+  updatedAt: string;
   avatar?: string;
 }
 

--- a/src/features/meeting/components/ParticipantList.tsx
+++ b/src/features/meeting/components/ParticipantList.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from 'react-i18next';
+import { MEETING_ROLE } from '@/shared';
+import { Text } from '@/components/ui';
+import SpinnerIcon from '@/assets/icons/spinner.svg?react';
+import type { MeetingMember } from '../types/meeting.types';
+
+interface ParticipantListProps {
+  participants: MeetingMember[];
+  currentUserId: string | undefined;
+  isSocketConnected: boolean;
+}
+
+export const ParticipantList = ({
+  participants,
+  currentUserId,
+  isSocketConnected,
+}: ParticipantListProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-3">
+      {!isSocketConnected && participants.length === 0 && (
+        <div className="flex items-center gap-2 text-gray-400">
+          <SpinnerIcon className="animate-spin h-4 w-4 shrink-0" />
+          <Text className="text-sm text-gray-400">{t('meeting.lobby.participantsLoading')}</Text>
+        </div>
+      )}
+
+      {isSocketConnected && participants.length === 0 && (
+        <Text className="text-sm text-gray-500">{t('meeting.lobby.participantsEmpty')}</Text>
+      )}
+
+      {participants.map((member) => (
+        <div
+          key={member.id}
+          className="flex items-center justify-between p-3 rounded-lg bg-gray-50"
+        >
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
+              <Text as="span" className="text-primary font-medium">
+                {member.userName?.charAt(0).toUpperCase() || '?'}
+              </Text>
+            </div>
+            <div>
+              <Text className="text-sm font-medium text-gray-900">
+                {member.userName}
+                {member.userId === currentUserId && (
+                  <Text as="span" className="ml-2 text-xs text-gray-500">
+                    {t('meeting.lobby.youLabel')}
+                  </Text>
+                )}
+              </Text>
+            </div>
+          </div>
+          {member.role === MEETING_ROLE.HOST && (
+            <Text
+              as="span"
+              className="px-2 py-1 bg-primary/10 text-primary rounded text-xs font-medium"
+            >
+              {t('meeting.role.host')}
+            </Text>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/features/meeting/components/ParticipantList.tsx
+++ b/src/features/meeting/components/ParticipantList.tsx
@@ -1,11 +1,10 @@
 import { useTranslation } from 'react-i18next';
-import { MEETING_ROLE } from '@/shared';
 import { Text } from '@/components/ui';
 import SpinnerIcon from '@/assets/icons/spinner.svg?react';
-import type { MeetingMember } from '../types/meeting.types';
+import type { ParticipantInfo } from '../types/meeting.types';
 
 interface ParticipantListProps {
-  participants: MeetingMember[];
+  participants: ParticipantInfo[];
   currentUserId: string | undefined;
   isSocketConnected: boolean;
 }
@@ -30,36 +29,24 @@ export const ParticipantList = ({
         <Text className="text-sm text-gray-500">{t('meeting.lobby.participantsEmpty')}</Text>
       )}
 
-      {participants.map((member) => (
+      {participants.map((participant) => (
         <div
-          key={member.id}
-          className="flex items-center justify-between p-3 rounded-lg bg-gray-50"
+          key={participant.socketId}
+          className="flex items-center gap-3 p-3 rounded-lg bg-gray-50"
         >
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
-              <Text as="span" className="text-primary font-medium">
-                {member.userName?.charAt(0).toUpperCase() || '?'}
-              </Text>
-            </div>
-            <div>
-              <Text className="text-sm font-medium text-gray-900">
-                {member.userName}
-                {member.userId === currentUserId && (
-                  <Text as="span" className="ml-2 text-xs text-gray-500">
-                    {t('meeting.lobby.youLabel')}
-                  </Text>
-                )}
-              </Text>
-            </div>
-          </div>
-          {member.role === MEETING_ROLE.HOST && (
-            <Text
-              as="span"
-              className="px-2 py-1 bg-primary/10 text-primary rounded text-xs font-medium"
-            >
-              {t('meeting.role.host')}
+          <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center shrink-0">
+            <Text as="span" className="text-primary font-medium">
+              {participant.name?.charAt(0).toUpperCase() || '?'}
             </Text>
-          )}
+          </div>
+          <Text className="text-sm font-medium text-gray-900">
+            {participant.name}
+            {participant.userId === currentUserId && (
+              <Text as="span" className="ml-2 text-xs text-gray-500">
+                {t('meeting.lobby.youLabel')}
+              </Text>
+            )}
+          </Text>
         </div>
       ))}
     </div>

--- a/src/features/meeting/components/meetingLobbyPage.tsx
+++ b/src/features/meeting/components/meetingLobbyPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/features/auth';
@@ -9,9 +9,10 @@ import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg?react';
 import CopyIcon from '@/assets/icons/copy.svg?react';
 import SpinnerIcon from '@/assets/icons/spinner.svg?react';
 import { meetingsApi } from '../services/meetingService';
-import { useMeetingSocket } from '../hooks';
+import { useMeetingSocket, useParticipants } from '../hooks';
 import { SOCKET_STATUS } from '../types/meeting.types';
 import type { MeetingLobbyData, ApiError } from '../types/meeting.types';
+import { ParticipantList } from './ParticipantList';
 
 export const MeetingLobbyPage = () => {
   const { t } = useTranslation();
@@ -21,11 +22,17 @@ export const MeetingLobbyPage = () => {
   // Use primitive userId as effect dependency to avoid re-fetching on object reference changes (rerender-dependencies)
   const userId = user?.id;
 
-  const { connectionStatus, error: socketError } = useMeetingSocket(id);
+  const { isConnected, connectionStatus, error: socketError, socket } = useMeetingSocket(id);
 
   const [lobbyData, setLobbyData] = useState<MeetingLobbyData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Stabilise the array reference to avoid an infinite re-render loop in
+  // useParticipants' "update state during render" pattern when lobbyData is null.
+  const meetingMembers = useMemo(() => lobbyData?.meeting.members ?? [], [lobbyData]);
+
+  const { participants, participantCount } = useParticipants(socket, id, meetingMembers, userId);
 
   const fetchMeetingData = useCallback(async () => {
     if (!id || !userId) return;
@@ -36,7 +43,7 @@ export const MeetingLobbyPage = () => {
     try {
       const meeting = await meetingsApi.getMeeting(id);
 
-      const currentMember = meeting.members.find((member) => member.id === userId);
+      const currentMember = meeting.members.find((member) => member.userId === userId);
       const currentUserRole = currentMember?.role || MEETING_ROLE.PARTICIPANT;
       const isHost = meeting.hostId === userId;
 
@@ -186,7 +193,7 @@ export const MeetingLobbyPage = () => {
                     as="span"
                     className="px-3 py-1 bg-green-100 text-green-700 rounded-full text-xs font-medium"
                   >
-                    {t(`meeting.status.${meeting.status}`)}
+                    {t(`meeting.status.${meeting.status ?? 'active'}`)}
                   </Text>
                 </div>
               </div>
@@ -203,48 +210,13 @@ export const MeetingLobbyPage = () => {
           <div className="lg:col-span-1">
             <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">
               <Heading level={2} className="text-lg font-semibold text-gray-900 mb-4">
-                {t('meeting.lobby.participantsTitle')} ({meeting.members.length})
+                {t('meeting.lobby.participantsTitle')} ({participantCount})
               </Heading>
-              <div className="space-y-3">
-                {meeting.members.length === 0 ? (
-                  <Text className="text-sm text-gray-500">
-                    {t('meeting.lobby.participantsEmpty')}
-                  </Text>
-                ) : (
-                  lobbyData.meeting.members.map((member) => (
-                    <div
-                      key={member.id}
-                      className="flex items-center justify-between p-3 rounded-lg bg-gray-50"
-                    >
-                      <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
-                          <Text as="span" className="text-primary font-medium">
-                            {member.userName?.charAt(0).toUpperCase() || '?'}
-                          </Text>
-                        </div>
-                        <div>
-                          <Text className="text-sm font-medium text-gray-900">
-                            {member.userName}
-                            {member.id === user?.id && (
-                              <Text as="span" className="ml-2 text-xs text-gray-500">
-                                {t('meeting.lobby.youLabel')}
-                              </Text>
-                            )}
-                          </Text>
-                        </div>
-                      </div>
-                      {member.role === MEETING_ROLE.HOST && (
-                        <Text
-                          as="span"
-                          className="px-2 py-1 bg-primary/10 text-primary rounded text-xs font-medium"
-                        >
-                          {t('meeting.role.host')}
-                        </Text>
-                      )}
-                    </div>
-                  ))
-                )}
-              </div>
+              <ParticipantList
+                participants={participants}
+                currentUserId={userId}
+                isSocketConnected={isConnected}
+              />
             </div>
           </div>
         </div>

--- a/src/features/meeting/components/meetingLobbyPage.tsx
+++ b/src/features/meeting/components/meetingLobbyPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/features/auth';
@@ -28,11 +28,7 @@ export const MeetingLobbyPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Stabilise the array reference to avoid an infinite re-render loop in
-  // useParticipants' "update state during render" pattern when lobbyData is null.
-  const meetingMembers = useMemo(() => lobbyData?.meeting.members ?? [], [lobbyData]);
-
-  const { participants, participantCount } = useParticipants(socket, id, meetingMembers, userId);
+  const { participants, participantCount } = useParticipants(socket, id);
 
   const fetchMeetingData = useCallback(async () => {
     if (!id || !userId) return;
@@ -210,7 +206,8 @@ export const MeetingLobbyPage = () => {
           <div className="lg:col-span-1">
             <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">
               <Heading level={2} className="text-lg font-semibold text-gray-900 mb-4">
-                {t('meeting.lobby.participantsTitle')} ({participantCount})
+                {t('meeting.lobby.participantsTitle')}
+                {isConnected ? ` (${participantCount})` : ''}
               </Heading>
               <ParticipantList
                 participants={participants}

--- a/src/features/meeting/hooks/index.ts
+++ b/src/features/meeting/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useMeetingSocket } from './useMeetingSocket';
+export { useParticipants } from './useParticipants';

--- a/src/features/meeting/hooks/useMeetingSocket.ts
+++ b/src/features/meeting/hooks/useMeetingSocket.ts
@@ -13,6 +13,7 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
     SOCKET_STATUS.IDLE,
   );
   const [error, setError] = useState<string | null>(null);
+  const [socket, setSocket] = useState<Socket | null>(null);
 
   useEffect(() => {
     if (!meetingId) {
@@ -39,6 +40,7 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
     const handleConnect = () => {
       setConnectionStatus(SOCKET_STATUS.CONNECTED);
       setError(null);
+      setSocket(socket);
       socket.emit('join-room', { meetingId });
     };
 
@@ -61,6 +63,7 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
       socket.removeAllListeners();
       socket.disconnect();
       socketRef.current = null;
+      setSocket(null);
       setConnectionStatus(SOCKET_STATUS.IDLE);
       setError(null);
     };
@@ -70,5 +73,6 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
     isConnected: connectionStatus === SOCKET_STATUS.CONNECTED,
     connectionStatus,
     error,
+    socket,
   };
 };

--- a/src/features/meeting/hooks/useMeetingSocket.ts
+++ b/src/features/meeting/hooks/useMeetingSocket.ts
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
-import { io, Socket } from 'socket.io-client';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { Socket } from 'socket.io-client';
 import { useAuth } from '@/features/auth';
 import { env } from '@/config';
+import { getMeetingSocket, destroyMeetingSocket } from '../services/socket';
 import { SOCKET_STATUS } from '../types/meeting.types';
 import type { SocketConnectionStatus, UseMeetingSocketReturn } from '../types/meeting.types';
 
@@ -15,10 +16,19 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
   const [error, setError] = useState<string | null>(null);
   const [socket, setSocket] = useState<Socket | null>(null);
 
-  useEffect(() => {
-    if (!meetingId) {
-      return;
+  /**
+   * Promote the watcher to an active video-call participant.
+   * Emits join-room and lets the server broadcast participant-joined to the room.
+   * Safe to call multiple times — the server is idempotent.
+   */
+  const joinRoom = useCallback(() => {
+    if (socketRef.current?.connected && meetingId) {
+      socketRef.current.emit('join-room', { meetingId });
     }
+  }, [meetingId]);
+
+  useEffect(() => {
+    if (!meetingId) return;
 
     if (!accessToken) {
       console.warn('[useMeetingSocket] accessToken is null — skipping connection');
@@ -30,18 +40,13 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
       return;
     }
 
-    const socket = io(env.socketUrl, {
-      autoConnect: false,
-      auth: { token: accessToken },
-    });
-
-    socketRef.current = socket;
+    const sock = getMeetingSocket(env.socketUrl, accessToken);
+    socketRef.current = sock;
 
     const handleConnect = () => {
       setConnectionStatus(SOCKET_STATUS.CONNECTED);
       setError(null);
-      setSocket(socket);
-      socket.emit('join-room', { meetingId });
+      setSocket(sock);
     };
 
     const handleConnectError = (err: Error) => {
@@ -53,15 +58,19 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
       setConnectionStatus(SOCKET_STATUS.DISCONNECTED);
     };
 
-    socket.on('connect', handleConnect);
-    socket.on('connect_error', handleConnectError);
-    socket.on('disconnect', handleDisconnect);
+    sock.on('connect', handleConnect);
+    sock.on('connect_error', handleConnectError);
+    sock.on('disconnect', handleDisconnect);
 
-    socket.connect();
+    if (!sock.connected) {
+      sock.connect();
+    }
 
     return () => {
-      socket.removeAllListeners();
-      socket.disconnect();
+      sock.off('connect', handleConnect);
+      sock.off('connect_error', handleConnectError);
+      sock.off('disconnect', handleDisconnect);
+      destroyMeetingSocket();
       socketRef.current = null;
       setSocket(null);
       setConnectionStatus(SOCKET_STATUS.IDLE);
@@ -74,5 +83,6 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
     connectionStatus,
     error,
     socket,
+    joinRoom,
   };
 };

--- a/src/features/meeting/hooks/useParticipants.ts
+++ b/src/features/meeting/hooks/useParticipants.ts
@@ -1,94 +1,68 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import type { Socket } from 'socket.io-client';
-import { MEETING_ROLE } from '@/shared';
-import type { MeetingRole } from '@/shared';
 import type {
-  MeetingMember,
+  ParticipantInfo,
   ParticipantJoinedPayload,
   ParticipantLeftPayload,
   ParticipantsListPayload,
   UseParticipantsReturn,
 } from '../types/meeting.types';
 
-const toISOString = (value: string | Date): string =>
-  value instanceof Date ? value.toISOString() : new Date(value).toISOString();
-
 export const useParticipants = (
   socket: Socket | null,
   meetingId: string | undefined,
-  initialMembers: MeetingMember[],
-  currentUserId: string | undefined,
 ): UseParticipantsReturn => {
-  // 'Update state during render' pattern: sync state from prop without useEffect
-  const [prevInitialMembers, setPrevInitialMembers] = useState(initialMembers);
-  const [participants, setParticipants] = useState(initialMembers);
-  const initialMembersRef = useRef(initialMembers);
-
-  if (prevInitialMembers !== initialMembers) {
-    setPrevInitialMembers(initialMembers);
-    setParticipants(initialMembers);
-  }
-
-  // Keep ref in sync so socket handlers can read the latest roles without
-  // needing initialMembers in the socket useEffect deps.
-  useEffect(() => {
-    initialMembersRef.current = initialMembers;
-  }, [initialMembers]);
+  const [participantMap, setParticipantMap] = useState<Record<string, ParticipantInfo>>({});
 
   useEffect(() => {
     if (!socket || !meetingId) return;
 
-    socket.emit('get-participants', { meetingId });
+    const handleParticipantsList = (payload: ParticipantsListPayload) => {
+      const map: Record<string, ParticipantInfo> = {};
 
-    const resolveRole = (userId: string): MeetingRole =>
-      initialMembersRef.current.find((m) => m.userId === userId)?.role ?? MEETING_ROLE.PARTICIPANT;
+      for (const p of payload.participants) {
+        map[p.userId] = p; // key by userId to deduplicate reconnects
+      }
+      setParticipantMap(map);
+    };
 
     const handleParticipantJoined = (payload: ParticipantJoinedPayload) => {
       const { participant } = payload;
-      setParticipants((prev) => {
-        const exists = prev.some((p) => p.userId === participant.userId);
-        if (exists) return prev;
-        return [
-          ...prev,
-          {
-            id: participant.userId,
-            userId: participant.userId,
-            userName: participant.name || 'Unknown User',
-            role: resolveRole(participant.userId),
-            joinedAt: toISOString(participant.joinedAt),
-          },
-        ];
+      setParticipantMap((prev) => {
+        if (prev[participant.userId]) return prev;
+        return { ...prev, [participant.userId]: participant };
       });
     };
 
     const handleParticipantLeft = (payload: ParticipantLeftPayload) => {
-      setParticipants((prev) => prev.filter((p) => p.userId !== payload.participant.userId));
+      const { userId } = payload.participant;
+      setParticipantMap((prev) => {
+        if (!prev[userId]) return prev;
+        const next = { ...prev };
+        delete next[userId];
+        return next;
+      });
     };
 
-    const handleParticipantsList = (payload: ParticipantsListPayload) => {
-      setParticipants(
-        payload.participants.map((p) => ({
-          id: p.userId,
-          userId: p.userId,
-          userName: p.name || 'Unknown User',
-          role: resolveRole(p.userId),
-          joinedAt: toISOString(p.joinedAt),
-        })),
-      );
-    };
-
+    socket.on('participants-list', handleParticipantsList);
     socket.on('participant-joined', handleParticipantJoined);
     socket.on('participant-left', handleParticipantLeft);
-    socket.on('participants-list', handleParticipantsList);
+
+    // Emit after listeners are registered so the response is never dropped.
+    socket.emit('watch-meeting', { meetingId });
 
     return () => {
+      socket.off('participants-list', handleParticipantsList);
       socket.off('participant-joined', handleParticipantJoined);
       socket.off('participant-left', handleParticipantLeft);
-      socket.off('participants-list', handleParticipantsList);
+      // Reset stale entries when this socket is torn down (on reconnect or
+      // unmount). By the time the new socket fires, the map is empty and
+      // participants-list will populate it fresh.
+      setParticipantMap({});
     };
   }, [socket, meetingId]);
 
-  void currentUserId;
+  const participants = Object.values(participantMap);
 
   return {
     participants,

--- a/src/features/meeting/hooks/useParticipants.ts
+++ b/src/features/meeting/hooks/useParticipants.ts
@@ -1,0 +1,97 @@
+import { useState, useEffect, useRef } from 'react';
+import type { Socket } from 'socket.io-client';
+import { MEETING_ROLE } from '@/shared';
+import type { MeetingRole } from '@/shared';
+import type {
+  MeetingMember,
+  ParticipantJoinedPayload,
+  ParticipantLeftPayload,
+  ParticipantsListPayload,
+  UseParticipantsReturn,
+} from '../types/meeting.types';
+
+const toISOString = (value: string | Date): string =>
+  value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+
+export const useParticipants = (
+  socket: Socket | null,
+  meetingId: string | undefined,
+  initialMembers: MeetingMember[],
+  currentUserId: string | undefined,
+): UseParticipantsReturn => {
+  // 'Update state during render' pattern: sync state from prop without useEffect
+  const [prevInitialMembers, setPrevInitialMembers] = useState(initialMembers);
+  const [participants, setParticipants] = useState(initialMembers);
+  const initialMembersRef = useRef(initialMembers);
+
+  if (prevInitialMembers !== initialMembers) {
+    setPrevInitialMembers(initialMembers);
+    setParticipants(initialMembers);
+  }
+
+  // Keep ref in sync so socket handlers can read the latest roles without
+  // needing initialMembers in the socket useEffect deps.
+  useEffect(() => {
+    initialMembersRef.current = initialMembers;
+  }, [initialMembers]);
+
+  useEffect(() => {
+    if (!socket || !meetingId) return;
+
+    socket.emit('get-participants', { meetingId });
+
+    const resolveRole = (userId: string): MeetingRole =>
+      initialMembersRef.current.find((m) => m.userId === userId)?.role ?? MEETING_ROLE.PARTICIPANT;
+
+    const handleParticipantJoined = (payload: ParticipantJoinedPayload) => {
+      const { participant } = payload;
+      setParticipants((prev) => {
+        const exists = prev.some((p) => p.userId === participant.userId);
+        if (exists) return prev;
+        return [
+          ...prev,
+          {
+            id: participant.userId,
+            userId: participant.userId,
+            userName: participant.name || 'Unknown User',
+            role: resolveRole(participant.userId),
+            joinedAt: toISOString(participant.joinedAt),
+          },
+        ];
+      });
+    };
+
+    const handleParticipantLeft = (payload: ParticipantLeftPayload) => {
+      setParticipants((prev) => prev.filter((p) => p.userId !== payload.participant.userId));
+    };
+
+    const handleParticipantsList = (payload: ParticipantsListPayload) => {
+      setParticipants(
+        payload.participants.map((p) => ({
+          id: p.userId,
+          userId: p.userId,
+          userName: p.name || 'Unknown User',
+          role: resolveRole(p.userId),
+          joinedAt: toISOString(p.joinedAt),
+        })),
+      );
+    };
+
+    socket.on('participant-joined', handleParticipantJoined);
+    socket.on('participant-left', handleParticipantLeft);
+    socket.on('participants-list', handleParticipantsList);
+
+    return () => {
+      socket.off('participant-joined', handleParticipantJoined);
+      socket.off('participant-left', handleParticipantLeft);
+      socket.off('participants-list', handleParticipantsList);
+    };
+  }, [socket, meetingId]);
+
+  void currentUserId;
+
+  return {
+    participants,
+    participantCount: participants.length,
+  };
+};

--- a/src/features/meeting/index.ts
+++ b/src/features/meeting/index.ts
@@ -3,6 +3,7 @@ export { MeetingLobbyPage } from './components/meetingLobbyPage';
 export { ParticipantList } from './components/ParticipantList';
 
 export { meetingsApi } from './services/meetingService';
+export { getMeetingSocket, destroyMeetingSocket } from './services/socket';
 export { useMeetingSocket, useParticipants } from './hooks';
 
 export { SOCKET_STATUS } from './types/meeting.types';
@@ -21,5 +22,7 @@ export type {
   ParticipantJoinedPayload,
   ParticipantLeftPayload,
   ParticipantsListPayload,
+  WatchMeetingPayload,
+  JoinRoomPayload,
   UseParticipantsReturn,
 } from './types/meeting.types';

--- a/src/features/meeting/index.ts
+++ b/src/features/meeting/index.ts
@@ -1,8 +1,9 @@
 export { StartMeetingPage } from './components/startMeetingPage';
 export { MeetingLobbyPage } from './components/meetingLobbyPage';
+export { ParticipantList } from './components/ParticipantList';
 
 export { meetingsApi } from './services/meetingService';
-export { useMeetingSocket } from './hooks';
+export { useMeetingSocket, useParticipants } from './hooks';
 
 export { SOCKET_STATUS } from './types/meeting.types';
 
@@ -16,4 +17,9 @@ export type {
   ApiError,
   SocketConnectionStatus,
   UseMeetingSocketReturn,
+  ParticipantInfo,
+  ParticipantJoinedPayload,
+  ParticipantLeftPayload,
+  ParticipantsListPayload,
+  UseParticipantsReturn,
 } from './types/meeting.types';

--- a/src/features/meeting/services/socket.ts
+++ b/src/features/meeting/services/socket.ts
@@ -1,0 +1,56 @@
+import { io } from 'socket.io-client';
+import type { Socket } from 'socket.io-client';
+
+/**
+ * Singleton Socket.IO client for the meeting signaling gateway.
+ *
+ * The gateway is shared across all hooks/components while the user is
+ * on a meeting page. A new socket is created when the url or token changes
+ * (e.g. after a token refresh). The previous socket is disconnected cleanly.
+ */
+
+let instance: Socket | null = null;
+let instanceUrl: string | null = null;
+let instanceToken: string | null = null;
+
+/**
+ * Return the existing socket if url+token are unchanged, otherwise create a
+ * fresh one (disconnecting the previous instance first).
+ *
+ * The returned socket has `autoConnect: false` — callers must call
+ * `socket.connect()` explicitly.
+ */
+export const getMeetingSocket = (url: string, token: string): Socket => {
+  if (instance && instanceUrl === url && instanceToken === token) {
+    return instance;
+  }
+
+  if (instance) {
+    instance.removeAllListeners();
+    instance.disconnect();
+  }
+
+  instance = io(url, {
+    autoConnect: false,
+    auth: { token },
+  });
+
+  instanceUrl = url;
+  instanceToken = token;
+
+  return instance;
+};
+
+/**
+ * Disconnect and destroy the singleton socket.
+ * Call this when the user leaves the meeting context entirely.
+ */
+export const destroyMeetingSocket = (): void => {
+  if (instance) {
+    instance.removeAllListeners();
+    instance.disconnect();
+    instance = null;
+    instanceUrl = null;
+    instanceToken = null;
+  }
+};

--- a/src/features/meeting/types/meeting.types.ts
+++ b/src/features/meeting/types/meeting.types.ts
@@ -1,6 +1,6 @@
+import type { Socket } from 'socket.io-client';
 import type { MeetingRole } from '@/shared';
 
-// Meeting member/participant
 export interface MeetingMember {
   id: string;
   userId: string;
@@ -9,17 +9,17 @@ export interface MeetingMember {
   joinedAt: string;
 }
 
-// Meeting entity
 export interface Meeting {
   id: string;
   title: string;
   hostId: string;
   members: MeetingMember[];
   createdAt: string;
-  status: 'active' | 'ended';
+  updatedAt: string;
+  /** Not returned by the backend — frontend-only field, treat as undefined unless set locally */
+  status?: 'active' | 'ended';
 }
 
-// API Request/Response types
 export interface CreateMeetingRequest {
   title?: string;
 }
@@ -28,29 +28,22 @@ export interface JoinMeetingRequest {
   meetingId: string;
 }
 
-export interface JoinMeetingResponse {
-  meeting: Meeting;
-}
+export type JoinMeetingResponse = Meeting;
 
-export interface GetMeetingResponse {
-  meeting: Meeting;
-}
+export type GetMeetingResponse = Meeting;
 
-// Derived types for UI
 export interface MeetingLobbyData {
   meeting: Meeting;
   currentUserRole: MeetingRole;
   isHost: boolean;
 }
 
-// Error types
 export interface ApiError {
   message: string;
   code: string;
   statusCode: number;
 }
 
-// Socket types
 export const SOCKET_STATUS = {
   IDLE: 'idle',
   CONNECTING: 'connecting',
@@ -65,4 +58,33 @@ export interface UseMeetingSocketReturn {
   isConnected: boolean;
   connectionStatus: SocketConnectionStatus;
   error: string | null;
+  socket: Socket | null;
+}
+
+export interface ParticipantInfo {
+  userId: string;
+  name: string;
+  socketId: string;
+  /** Arrives as a string over WebSocket JSON; may be a Date when constructed locally. */
+  joinedAt: string | Date;
+}
+
+export interface ParticipantJoinedPayload {
+  meetingId: string;
+  participant: ParticipantInfo;
+}
+
+export interface ParticipantLeftPayload {
+  meetingId: string;
+  participant: ParticipantInfo;
+}
+
+export interface ParticipantsListPayload {
+  meetingId: string;
+  participants: ParticipantInfo[];
+}
+
+export interface UseParticipantsReturn {
+  participants: MeetingMember[];
+  participantCount: number;
 }

--- a/src/features/meeting/types/meeting.types.ts
+++ b/src/features/meeting/types/meeting.types.ts
@@ -59,14 +59,26 @@ export interface UseMeetingSocketReturn {
   connectionStatus: SocketConnectionStatus;
   error: string | null;
   socket: Socket | null;
+  /** Emit join-room to promote from lobby watcher to video call participant */
+  joinRoom: () => void;
 }
 
 export interface ParticipantInfo {
+  socketId: string;
   userId: string;
   name: string;
-  socketId: string;
-  /** Arrives as a string over WebSocket JSON; may be a Date when constructed locally. */
-  joinedAt: string | Date;
+  /** Unix timestamp (Date.now()) as documented in socket-signaling.md */
+  joinedAt: number;
+}
+
+/** Client → Server: subscribe to lobby presence without joining the video call */
+export interface WatchMeetingPayload {
+  meetingId: string;
+}
+
+/** Client → Server: join the active video call */
+export interface JoinRoomPayload {
+  meetingId: string;
 }
 
 export interface ParticipantJoinedPayload {
@@ -85,6 +97,6 @@ export interface ParticipantsListPayload {
 }
 
 export interface UseParticipantsReturn {
-  participants: MeetingMember[];
+  participants: ParticipantInfo[];
   participantCount: number;
 }

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -95,6 +95,7 @@
       "comingSoonText": "Video chat and screen sharing will be available here.",
       "participantsTitle": "Participants",
       "participantsEmpty": "No participants yet",
+      "participantsLoading": "Connecting...",
       "youLabel": "(You)",
       "errorNotFound": "Meeting not found",
       "errorUnauthorized": "You are not authorized to access this meeting",


### PR DESCRIPTION
## Description
- Extract participant list rendering into a dedicated ParticipantList component
- Implement useParticipants hook listening to participant-joined, participant-left, and participants-list socket events
- Extend useMeetingSocket to expose the active socket instance for downstream hooks
- Add TypeScript types for socket event payloads
- Seed list from REST response on load; live updates via socket thereafter
- Stabilise meetingMembers reference with useMemo to prevent render loops
- Fix member lookup to use member.userId; guard meeting.status with fallback

## Test plan
- [x] Participant list populates from initial REST response on page load
- [ ] Second tab joining updates the first tab list in real-time
- [ ] Leaving updates the list without reload
- [x] Socket error banner shown on disconnect; last known list remains visible
- [x] No lingering socket listeners after navigating away
