### PR TITLE
feat(meeting): implement WebRTC peer connection manager

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,4 +3,4 @@
 
 VITE_API_URL=http://localhost:3000/api
 VITE_WS_URL=ws://localhost:3000
-VITE_WEBRTC_STUN_URL=stun:stun.l.google.com:19302
+VITE_STUN_URL=stun:stun.l.google.com:19302

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_API_BASE_URL=http://localhost:3000
 VITE_WS_URL=ws://localhost:3000
+VITE_STUN_URL=stun:stun.l.google.com:19302

--- a/.github/plans/WM-7.md
+++ b/.github/plans/WM-7.md
@@ -1,0 +1,169 @@
+# WM-7: Implement WebRTC Peer Connection Manager
+
+---
+
+## 1. Feature Summary
+
+This feature introduces a usePeerConnections hook that creates and maintains a Map of peerId to RTCPeerConnection for each remote participant in the meeting room. It exposes createPeerConnection(peerId) -- which instantiates an RTCPeerConnection, adds local media tracks, and tracks per-peer connection state -- and closePeerConnection(peerId) -- which closes and removes the connection. All connections are closed automatically on unmount. This hook is the foundational WebRTC transport layer that subsequent signalling issues (SDP offer/answer, ICE) will build upon.
+
+---
+
+## 2. Problem Statement
+
+Audio and video in a WebRTC mesh meeting require an RTCPeerConnection instance per remote participant. Currently the meeting frontend has no such layer: signalling events have no connection object to act on, local media tracks cannot be attached to remote peers, and there is no mechanism to enforce the 4-participant mesh limit. Without this hook, every subsequent WebRTC feature (offer/answer, ICE, remote streams) is blocked. WM-7 closes this gap by providing a single, composable hook that manages the full peer connection lifecycle.
+
+---
+
+## 3. Feature Type
+
+**Feature Type:** Frontend
+
+All work is confined to client-side WebRTC API usage inside a custom React hook; no backend gateway code is affected in this issue.
+
+---
+
+## 4. Technical Design
+
+### Frontend
+
+**New files:**
+- src/features/meeting/hooks/usePeerConnections.ts -- the peer connection manager hook.
+
+**Files to modify:**
+- src/config/env.ts -- add stunUrl: import.meta.env.VITE_STUN_URL.
+- src/features/meeting/types/meeting.types.ts -- add PeerConnectionStatus union type and UsePeerConnectionsReturn interface.
+- src/features/meeting/hooks/index.ts -- export usePeerConnections.
+- src/features/meeting/index.ts -- export usePeerConnections and UsePeerConnectionsReturn.
+
+**Hook signature -- usePeerConnections(stream: MediaStream | null): UsePeerConnectionsReturn:**
+
+Internal data structures:
+
+- peerConnectionsRef -- useRef(new Map()) holding RTCPeerConnection instances keyed by peerId. Stored in a ref so that createPeerConnection and closePeerConnection can mutate it without triggering re-renders.
+- peerStatuses -- useState(Record string to PeerConnectionStatus) -- reactive per-peer status that drives consumer re-renders.
+- isUnmountedRef -- useRef(false) -- unmount guard following the same pattern as useMeetingSocket.
+
+Constants defined at module level:
+
+- MAX_PEER_CONNECTIONS = 3
+- DEFAULT_STUN = stun:stun.l.google.com:19302
+
+**createPeerConnection(peerId: string): RTCPeerConnection | null**
+
+1. If peerConnectionsRef.current.size >= MAX_PEER_CONNECTIONS, console.warn and return null.
+2. If a connection for peerId already exists, close it before replacing (idempotent).
+3. Read STUN URL from env.stunUrl ?? DEFAULT_STUN.
+4. Instantiate new RTCPeerConnection({ iceServers: [{ urls: stunUrl }] }).
+5. If stream is non-null, call stream.getTracks().forEach(track => pc.addTrack(track, stream)).
+6. Attach connectionstatechange listener: update peerStatuses for peerId with pc.connectionState; guard with isUnmountedRef and map.has(peerId).
+7. Add connection to peerConnectionsRef.current.
+8. Set peerStatuses for peerId to connecting immediately.
+9. Return the RTCPeerConnection instance.
+
+**closePeerConnection(peerId: string): void**
+
+1. Retrieve connection; return early if not found.
+2. Remove senders via pc.getSenders().forEach(s => pc.removeTrack(s)).
+3. Call pc.close() inside try/catch; log error and continue on failure.
+4. Delete from peerConnectionsRef.current.
+5. Update peerStatuses: remove the peerId entry via functional setState.
+
+**Cleanup useEffect (no deps):**
+
+Set isUnmountedRef.current = true. Iterate peerConnectionsRef.current, close each PC, clear the map. Reset peerStatuses to {}.
+
+**UsePeerConnectionsReturn interface:**
+
+- createPeerConnection: (peerId: string) => RTCPeerConnection | null
+- closePeerConnection: (peerId: string) => void
+- peerStatuses: Record<string, PeerConnectionStatus>
+- peerCount: number  (derived: Object.keys(peerStatuses).length)
+
+### State Management
+
+- The Map lives in useRef -- mutated directly, does not trigger re-renders.
+- peerStatuses lives in useState -- reactive surface for consumers.
+- createPeerConnection and closePeerConnection wrapped in useCallback (dep: stream).
+- No Zustand store introduced; follows the same local state pattern as useMeetingSocket and useParticipants.
+
+### Realtime / External Services
+
+- Browser WebRTC API: RTCPeerConnection -- standard browser API, no library needed.
+- STUN server: read from env.stunUrl (VITE_STUN_URL); defaults to stun:stun.l.google.com:19302 if not set.
+- No new socket events consumed or emitted (SDP and ICE signalling are out of scope).
+
+---
+
+## 7. Edge Cases
+
+- **createPeerConnection called when map.size >= 3** -- console.warn and return null without modifying the map.
+- **createPeerConnection for an existing peerId** -- close the old connection first; prevents dangling connections.
+- **stream is null at time of createPeerConnection** -- skip addTrack; console.warn; do not crash.
+- **stream changes after peer connections are already created** -- existing RTCPeerConnection instances retain old tracks; re-negotiation is out of scope; document limitation.
+- **connectionstatechange fires after closePeerConnection** -- guard with peerConnectionsRef.current.has(peerId) before updating state.
+- **closePeerConnection for unknown peerId** -- no-op; return early without crashing.
+- **pc.close() throws** -- wrap in try/catch; log and continue to delete from map.
+- **Unmount during pending connectionstatechange** -- isUnmountedRef guard prevents setState after unmount.
+- **VITE_STUN_URL not set** -- fall back to DEFAULT_STUN; console.warn on first createPeerConnection call.
+- **RTCPeerConnection undefined (old browser)** -- guard typeof RTCPeerConnection; log error and return null.
+
+---
+
+## 8. Implementation Plan
+
+1. **Add stunUrl to env config** -- append stunUrl: import.meta.env.VITE_STUN_URL to src/config/env.ts.
+2. **Add types** -- add PeerConnectionStatus union type and UsePeerConnectionsReturn interface to meeting.types.ts.
+3. **Implement usePeerConnections hook** -- create src/features/meeting/hooks/usePeerConnections.ts with all logic described in section 4.
+4. **Export from hooks barrel** -- add usePeerConnections to src/features/meeting/hooks/index.ts.
+5. **Export from feature barrel** -- add usePeerConnections and UsePeerConnectionsReturn to src/features/meeting/index.ts.
+6. **Run pnpm lint && pnpm type-check** -- fix all errors.
+
+---
+
+## 9. Implementation Order
+
+1. Add stunUrl: import.meta.env.VITE_STUN_URL to src/config/env.ts
+2. Add PeerConnectionStatus union type to src/features/meeting/types/meeting.types.ts
+3. Add UsePeerConnectionsReturn interface to src/features/meeting/types/meeting.types.ts
+4. Create src/features/meeting/hooks/usePeerConnections.ts with full hook implementation
+5. Export usePeerConnections from src/features/meeting/hooks/index.ts
+6. Export usePeerConnections and UsePeerConnectionsReturn from src/features/meeting/index.ts
+7. Run pnpm lint && pnpm type-check; fix all errors
+
+---
+
+## 10. Task Breakdown
+
+**Frontend**
+
+- [ ] Add stunUrl: import.meta.env.VITE_STUN_URL to src/config/env.ts
+- [ ] Add PeerConnectionStatus union type to meeting.types.ts
+- [ ] Add UsePeerConnectionsReturn interface to meeting.types.ts
+- [ ] Define MAX_PEER_CONNECTIONS = 3 and DEFAULT_STUN constants in usePeerConnections.ts
+- [ ] Declare peerConnectionsRef (useRef Map) in usePeerConnections
+- [ ] Declare peerStatuses (useState Record) in usePeerConnections
+- [ ] Declare isUnmountedRef (useRef boolean) in usePeerConnections
+- [ ] Implement createPeerConnection with mesh-limit guard, duplicate guard, RTCPeerConnection instantiation, addTrack, connectionstatechange listener
+- [ ] Implement closePeerConnection with sender removal, pc.close(), map delete, peerStatuses cleanup
+- [ ] Write cleanup useEffect (no deps) closing all PCs and resetting state
+- [ ] Wrap createPeerConnection and closePeerConnection with useCallback (dep: stream)
+- [ ] Export usePeerConnections from src/features/meeting/hooks/index.ts
+- [ ] Export usePeerConnections from src/features/meeting/index.ts
+- [ ] Export UsePeerConnectionsReturn type from src/features/meeting/index.ts
+
+**Shared / Cross-cutting**
+
+- [ ] Add VITE_STUN_URL=stun:stun.l.google.com:19302 to .env (or .env.example)
+- [ ] Run pnpm lint && pnpm type-check with no errors
+
+**Testing**
+
+- [ ] Hook test: createPeerConnection returns RTCPeerConnection with getSenders() populated when stream is provided
+- [ ] Hook test: createPeerConnection returns null and does not mutate map when size >= MAX_PEER_CONNECTIONS
+- [ ] Hook test: createPeerConnection for existing peerId closes old connection before inserting new one
+- [ ] Hook test: createPeerConnection skips addTrack and does not crash when stream is null
+- [ ] Hook test: connectionstatechange updates peerStatuses for the correct peerId
+- [ ] Hook test: closePeerConnection removes connection from map and updates peerStatuses
+- [ ] Hook test: closePeerConnection for unknown peerId is a no-op
+- [ ] Hook test: unmount closes all open connections and clears peerStatuses
+- [ ] Hook test: connectionstatechange after closePeerConnection does not crash

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,5 @@
 export const env = {
   apiBaseUrl: import.meta.env.VITE_API_BASE_URL,
   socketUrl: import.meta.env.VITE_WS_URL,
+  stunUrl: import.meta.env.VITE_STUN_URL,
 } as const;

--- a/src/features/meeting/components/LocalVideoPreview.tsx
+++ b/src/features/meeting/components/LocalVideoPreview.tsx
@@ -39,7 +39,7 @@ export const LocalVideoPreview = ({ stream, isLoading, error }: LocalVideoPrevie
   }
 
   return (
-    <div className="relative h-48 overflow-hidden rounded-lg bg-black">
+    <div className="relative overflow-hidden rounded-lg bg-black">
       <video
         ref={videoRef}
         autoPlay

--- a/src/features/meeting/hooks/index.ts
+++ b/src/features/meeting/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useMeetingSocket } from './useMeetingSocket';
 export { useParticipants } from './useParticipants';
 export { useLocalMedia } from './useLocalMedia';
+export { usePeerConnections } from './usePeerConnections';

--- a/src/features/meeting/hooks/useMeetingSocket.ts
+++ b/src/features/meeting/hooks/useMeetingSocket.ts
@@ -5,6 +5,7 @@ import { env } from '@/config';
 import { getMeetingSocket, destroyMeetingSocket } from '../services/socket';
 import { SOCKET_STATUS } from '../types/meeting.types';
 import type { SocketConnectionStatus, UseMeetingSocketReturn } from '../types/meeting.types';
+import { SOCKET_REASONS_ERROR } from '../types/socket.types';
 
 const MAX_RECONNECT_ATTEMPTS = 5;
 
@@ -80,7 +81,6 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
     };
 
     const handleConnect = () => {
-      // Clear any pending reconnect timer
       if (reconnectTimerRef.current !== null) {
         clearTimeout(reconnectTimerRef.current);
         reconnectTimerRef.current = null;
@@ -105,7 +105,7 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
 
     const handleDisconnect = (reason: string) => {
       // Intentional disconnect from cleanup — skip reconnect loop entirely
-      if (reason === 'io client disconnect') return;
+      if (reason === SOCKET_REASONS_ERROR.IO_CLIENT_DISCONNECT) return;
 
       setConnectionStatus(SOCKET_STATUS.RECONNECTING);
       setIsReconnecting(true);

--- a/src/features/meeting/hooks/usePeerConnections.ts
+++ b/src/features/meeting/hooks/usePeerConnections.ts
@@ -1,0 +1,144 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { env } from '@/config/env';
+import type { PeerConnectionStatus, UsePeerConnectionsReturn } from '../types/meeting.types';
+
+const MAX_PEER_CONNECTIONS = 3;
+const DEFAULT_STUN = 'stun:stun.l.google.com:19302';
+let stunWarnedOnce = false;
+export const usePeerConnections = (stream: MediaStream | null): UsePeerConnectionsReturn => {
+  const peerConnectionsRef = useRef<Map<string, RTCPeerConnection>>(new Map());
+  const [peerStatuses, setPeerStatuses] = useState<Record<string, PeerConnectionStatus>>({});
+  const isUnmountedRef = useRef<boolean>(false);
+
+  const createPeerConnection = useCallback(
+    (peerId: string): RTCPeerConnection | null => {
+      // Guard: old browser without RTCPeerConnection
+      if (typeof RTCPeerConnection === 'undefined') {
+        console.error('[usePeerConnections] RTCPeerConnection is not supported in this browser.');
+        return null;
+      }
+
+      const map = peerConnectionsRef.current;
+      // Close existing connection for this peer before replacing (always allowed, even when map is full)
+      if (map.has(peerId)) {
+        const existing = map.get(peerId)!;
+        try {
+          existing.getSenders().forEach((s) => existing.removeTrack(s));
+          existing.close();
+        } catch (err) {
+          console.warn(
+            `[usePeerConnections] Error closing existing connection for "${peerId}":`,
+            err,
+          );
+        }
+        map.delete(peerId);
+        setPeerStatuses((prev) => {
+          const next = { ...prev };
+          delete next[peerId];
+          return next;
+        });
+      }
+
+      // Guard: mesh limit (checked after duplicate removal so replacing an existing peer is always permitted)
+      if (map.size >= MAX_PEER_CONNECTIONS) {
+        console.warn(
+          `[usePeerConnections] Cannot create connection for "${peerId}": mesh limit (${MAX_PEER_CONNECTIONS}) reached.`,
+        );
+        return null;
+      }
+
+      // Guard: warn when stream is null
+      if (stream === null) {
+        console.warn(
+          `[usePeerConnections] createPeerConnection("${peerId}"): stream is null, addTrack will be skipped.`,
+        );
+      }
+
+      // Resolve STUN URL
+      const stunUrl = env.stunUrl ?? DEFAULT_STUN;
+      if (!env.stunUrl && !stunWarnedOnce) {
+        stunWarnedOnce = true;
+        console.warn(
+          '[usePeerConnections] VITE_STUN_URL is not set; falling back to default STUN server.',
+        );
+      }
+
+      const pc = new RTCPeerConnection({ iceServers: [{ urls: stunUrl }] });
+
+      // Add local tracks
+      if (stream !== null) {
+        stream.getTracks().forEach((track) => pc.addTrack(track, stream));
+      }
+
+      // Track connection state changes
+      pc.addEventListener('connectionstatechange', () => {
+        if (isUnmountedRef.current) return;
+        if (!peerConnectionsRef.current.has(peerId)) return;
+        setPeerStatuses((prev) => ({
+          ...prev,
+          [peerId]: pc.connectionState as PeerConnectionStatus,
+        }));
+      });
+
+      map.set(peerId, pc);
+
+      // Set initial status
+      setPeerStatuses((prev) => ({ ...prev, [peerId]: 'connecting' }));
+
+      return pc;
+    },
+    [stream],
+  );
+
+  const closePeerConnection = useCallback((peerId: string): void => {
+    const map = peerConnectionsRef.current;
+    const pc = map.get(peerId);
+    if (!pc) return;
+
+    pc.getSenders().forEach((s) => {
+      try {
+        pc.removeTrack(s);
+      } catch (err) {
+        console.warn(`[usePeerConnections] removeTrack error for "${peerId}":`, err);
+      }
+    });
+
+    try {
+      pc.close();
+    } catch (err) {
+      console.error(`[usePeerConnections] pc.close() error for "${peerId}":`, err);
+    }
+
+    map.delete(peerId);
+
+    setPeerStatuses((prev) => {
+      const next = { ...prev };
+      delete next[peerId];
+      return next;
+    });
+  }, []);
+
+  // Cleanup: close all peer connections on unmount
+  useEffect(() => {
+    const map = peerConnectionsRef.current;
+    return () => {
+      isUnmountedRef.current = true;
+      map.forEach((pc) => {
+        try {
+          pc.close();
+        } catch {
+          // Ignore close errors during teardown
+        }
+      });
+      map.clear();
+      setPeerStatuses({});
+    };
+  }, []);
+
+  return {
+    createPeerConnection,
+    closePeerConnection,
+    peerStatuses,
+    peerCount: Object.keys(peerStatuses).length,
+  };
+};

--- a/src/features/meeting/index.ts
+++ b/src/features/meeting/index.ts
@@ -5,7 +5,7 @@ export { LocalVideoPreview } from './components/LocalVideoPreview';
 
 export { meetingsApi } from './services/meetingService';
 export { getMeetingSocket, destroyMeetingSocket } from './services/socket';
-export { useMeetingSocket, useParticipants, useLocalMedia } from './hooks';
+export { useMeetingSocket, useParticipants, useLocalMedia, usePeerConnections } from './hooks';
 
 export { SOCKET_STATUS } from './types/meeting.types';
 
@@ -27,4 +27,6 @@ export type {
   JoinRoomPayload,
   UseParticipantsReturn,
   UseLocalMediaReturn,
+  PeerConnectionStatus,
+  UsePeerConnectionsReturn,
 } from './types/meeting.types';

--- a/src/features/meeting/types/meeting.types.ts
+++ b/src/features/meeting/types/meeting.types.ts
@@ -110,3 +110,18 @@ export interface UseLocalMediaReturn {
   isLoading: boolean;
   error: string | null;
 }
+
+export type PeerConnectionStatus =
+  | 'new'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'failed'
+  | 'closed';
+
+export interface UsePeerConnectionsReturn {
+  createPeerConnection: (peerId: string) => RTCPeerConnection | null;
+  closePeerConnection: (peerId: string) => void;
+  peerStatuses: Record<string, PeerConnectionStatus>;
+  peerCount: number;
+}

--- a/src/features/meeting/types/socket.types.ts
+++ b/src/features/meeting/types/socket.types.ts
@@ -1,0 +1,7 @@
+export const SOCKET_REASONS_ERROR = {
+  IO_SERVER_DISCONNECT: 'io server disconnect',
+  IO_CLIENT_DISCONNECT: 'io client disconnect',
+  PING_TIMEOUT: 'ping timeout',
+  TRANSPORT_CLOSE: 'transport close',
+  TRANSPORT_ERROR: 'transport error',
+} as const;


### PR DESCRIPTION
## References
- #15

## Description
- Implement usePeerConnections hook managing Map of peerId to RTCPeerConnection for WebRTC mesh sessions
- Enforce mesh limit of 3 simultaneous peer connections; createPeerConnection returns null at limit
- Guard duplicate peerId by closing existing connection before replacing
- Track per-peer state via connectionstatechange; expose peerStatuses and peerCount
- Clean up all connections on unmount via isUnmountedRef guard
- Add VITE_STUN_URL env var; fall back to default Google STUN if unset
- Extract SOCKET_REASONS_ERROR into socket.types.ts; replace magic string in useMeetingSocket
- Remove fixed h-48 height from LocalVideoPreview wrapper

## Test plan
- [ ] createPeerConnection with stream returns RTCPeerConnection with tracks in getSenders()
- [ ] createPeerConnection returns null without mutating map when size >= 3
- [ ] createPeerConnection for existing peerId closes old connection first
- [ ] closePeerConnection removes peer from map and peerStatuses
- [ ] Unmounting closes all open connections and clears peerStatuses
- [ ] pnpm lint and pnpm type-check pass with no errors
