### PR TITLE
feat(meeting): add WebRTC signaling for SDP and ICE exchange

### DIFF
--- a/.github/plans/WM-8.md
+++ b/.github/plans/WM-8.md
@@ -1,0 +1,186 @@
+# WM-8: Integrate WebRTC Signaling for SDP and ICE Exchange
+
+---
+
+## 1. Feature Summary
+
+This feature wires the WebRTC signaling layer between participants by implementing a useSignaling hook. The hook listens to socket events (offer, answer, ice-candidate, participant-joined) and drives RTCPeerConnection negotiation -- creating offers, setting remote descriptions, emitting answers, and routing ICE candidates -- so that audio and video media can flow between participants in the meeting room.
+
+---
+
+## 2. Problem Statement
+
+The peer connection objects created by usePeerConnections (WM-7) are fully initialised but have no signaling layer to negotiate sessions. Without SDP offer/answer exchange and bidirectional ICE candidate routing, every RTCPeerConnection stays in the new state indefinitely and no media flows between participants. WM-8 closes this gap by plugging socket signaling events directly into the peer connection lifecycle.
+
+---
+
+## 3. Feature Type
+
+**Feature Type:** Frontend
+
+All work is confined to a new client-side React hook (useSignaling) that orchestrates browser WebRTC APIs and the socket.io-client instance managed by useMeetingSocket. No backend code is modified.
+
+---
+
+## 4. Technical Design
+
+### Frontend
+
+**New files:**
+- src/features/meeting/hooks/useSignaling.ts
+
+**Files to modify:**
+- src/features/meeting/types/meeting.types.ts -- add OfferPayload, AnswerPayload, IceCandidatePayload, UseSignalingReturn types.
+- src/features/meeting/hooks/index.ts -- export useSignaling.
+- src/features/meeting/index.ts -- export useSignaling and UseSignalingReturn.
+- src/features/meeting/hooks/usePeerConnections.ts -- add getPeerConnection getter.
+
+**Hook signature:**
+
+  useSignaling(socket, meetingId, createPeerConnection, closePeerConnection, getPeerConnection)
+
+**Internal refs (no re-renders):**
+
+- iceCandidateQueuesRef -- useRef(new Map()) -- buffers RTCIceCandidateInit per peer before remote description is set.
+- remoteDescriptionSetRef -- useRef(new Set()) -- tracks which peers have had setRemoteDescription called.
+- isUnmountedRef -- useRef(false) -- unmount guard, same pattern as useMeetingSocket.
+
+**Event handlers registered in a single useEffect keyed on [socket, meetingId, createPeerConnection, closePeerConnection, getPeerConnection]:**
+
+1. handleParticipantJoined (participant-joined):
+   - Validate payload.participant.userId; warn and return if malformed.
+   - Call createPeerConnection(userId); return if null (mesh limit).
+   - Attach onicecandidate to pc: emit ice-candidate event via socket.
+   - createOffer -> setLocalDescription -> emit offer { peerId, sdp }.
+   - All async in try/catch; closePeerConnection on error.
+
+2. handleOffer (offer):
+   - Validate payload.peerId and payload.sdp.
+   - createPeerConnection(peerId); attach onicecandidate.
+   - setRemoteDescription; mark remoteDescriptionSetRef; drain ICE queue.
+   - createAnswer -> setLocalDescription -> emit answer { peerId, sdp }.
+
+3. handleAnswer (answer):
+   - Validate payload.peerId and payload.sdp.
+   - getPeerConnection(peerId); return if undefined.
+   - setRemoteDescription; mark remoteDescriptionSetRef; drain ICE queue.
+
+4. handleIceCandidate (ice-candidate):
+   - Validate payload.peerId and payload.candidate.
+   - If remoteDescriptionSetRef has peerId: addIceCandidate immediately.
+   - Otherwise buffer in iceCandidateQueuesRef for this peer.
+
+**drainIceCandidateQueue(peerId, pc) helper:**
+- Retrieve queue; call addIceCandidate for each entry; clear queue.
+
+**Exposing getPeerConnection:**
+
+Extend UsePeerConnectionsReturn with getPeerConnection: (peerId: string) => RTCPeerConnection | undefined. Implement via peerConnectionsRef.current.get(peerId) in usePeerConnections.ts.
+
+### State Management
+
+- isNegotiating (useState boolean) and negotiationErrors (useState Record string) held in state for UI reactivity.
+- All buffers held in useRef -- mutated without re-renders.
+- Event handlers defined inline inside useEffect to avoid stale closures; no useCallback needed.
+- No Zustand store -- state scoped to meeting session lifetime.
+
+### Realtime / External Services
+
+Events consumed:
+
+| Event | Direction | Payload | When |
+| --- | --- | --- | --- |
+| participant-joined | server to client | { meetingId, participant: { userId, ... } } | Remote participant joins |
+| offer | server to client | { peerId, sdp } | Remote peer sends offer |
+| answer | server to client | { peerId, sdp } | Remote peer answers |
+| ice-candidate | server to client | { peerId, candidate } | Remote ICE candidate |
+
+Events emitted:
+
+| Event | Direction | Payload | When |
+| --- | --- | --- | --- |
+| offer | client to server | { peerId, sdp } | After local offer created |
+| answer | client to server | { peerId, sdp } | After accepting remote offer |
+| ice-candidate | client to server | { peerId, candidate } | Local ICE candidate generated |
+
+Confirm event names with backend gateway owner before implementing.
+
+---
+## 7. Edge Cases
+
+- **createPeerConnection returns null (mesh limit):** Log and return from handleParticipantJoined without emitting offer.
+- **ICE candidate before setRemoteDescription:** Buffer in iceCandidateQueuesRef per peer; drain after setRemoteDescription completes.
+- **handleAnswer needs existing PC:** getPeerConnection(peerId) getter provides access; if undefined log and return.
+- **Duplicate participant-joined for same peer:** createPeerConnection closes old connection; clear per-peer buffers in remoteDescriptionSetRef and iceCandidateQueuesRef before re-negotiating.
+- **createOffer or setLocalDescription throws:** Wrap in try/catch; call closePeerConnection(peerId); set negotiationErrors[peerId].
+- **Socket goes null mid-negotiation (reconnect):** useEffect cleanup removes all listeners and clears buffers; renegotiation restarts when socket is restored.
+- **setRemoteDescription called with wrong SDP type:** Caught by try/catch; peer cleaned up; error in negotiationErrors.
+- **Component unmounts during async round-trip:** isUnmountedRef guard prevents state updates and socket emits after unmount.
+- **ICE candidate for unknown peerId:** getPeerConnection returns undefined; log and discard without queuing.
+- **addIceCandidate failures during drain:** Ignore individual errors; continue draining remaining candidates.
+
+---
+
+## 8. Implementation Plan
+
+1. **Extend UsePeerConnectionsReturn** -- add getPeerConnection getter; implement in usePeerConnections.ts.
+2. **Add signaling types** -- add OfferPayload, AnswerPayload, IceCandidatePayload, UseSignalingReturn to meeting.types.ts.
+3. **Implement useSignaling hook** -- create useSignaling.ts with refs, state, four handlers, drainIceCandidateQueue, and cleanup.
+4. **Export from hooks barrel** -- add useSignaling to hooks/index.ts.
+5. **Export from feature barrel** -- add useSignaling and UseSignalingReturn to meeting/index.ts.
+6. **Integrate into meetingLobbyPage** -- call useSignaling with socket, meetingId, and the three peer connection functions.
+7. **Run pnpm lint and pnpm type-check** -- fix all errors.
+
+---
+
+## 9. Implementation Order
+
+1. Add getPeerConnection to UsePeerConnectionsReturn in meeting.types.ts; implement in usePeerConnections.ts
+2. Add OfferPayload, AnswerPayload, IceCandidatePayload, UseSignalingReturn to meeting.types.ts
+3. Create src/features/meeting/hooks/useSignaling.ts
+4. Export useSignaling from src/features/meeting/hooks/index.ts
+5. Export useSignaling and UseSignalingReturn from src/features/meeting/index.ts
+6. Call useSignaling in meetingLobbyPage.tsx
+7. Run pnpm lint and pnpm type-check; fix all errors
+8. Write hook tests
+
+---
+
+## 10. Task Breakdown
+
+**Frontend**
+
+- [ ] Add getPeerConnection: (peerId: string) => RTCPeerConnection | undefined to UsePeerConnectionsReturn in meeting.types.ts
+- [ ] Implement getPeerConnection in usePeerConnections.ts via peerConnectionsRef.current.get(peerId)
+- [ ] Add OfferPayload interface to meeting.types.ts
+- [ ] Add AnswerPayload interface to meeting.types.ts
+- [ ] Add IceCandidatePayload interface to meeting.types.ts
+- [ ] Add UseSignalingReturn interface (isNegotiating, negotiationErrors) to meeting.types.ts
+- [ ] Create src/features/meeting/hooks/useSignaling.ts
+- [ ] Implement iceCandidateQueuesRef, remoteDescriptionSetRef, isUnmountedRef inside hook
+- [ ] Implement drainIceCandidateQueue(peerId, pc) helper
+- [ ] Implement handleParticipantJoined: validate, createPeerConnection, onicecandidate, createOffer, emit offer
+- [ ] Implement handleOffer: validate, createPeerConnection, onicecandidate, setRemoteDescription, drain queue, createAnswer, emit answer
+- [ ] Implement handleAnswer: validate, getPeerConnection, setRemoteDescription, drain queue
+- [ ] Implement handleIceCandidate: validate, route to addIceCandidate or buffer
+- [ ] Register all four listeners in single useEffect; deregister and clear buffers in cleanup
+- [ ] Export useSignaling from src/features/meeting/hooks/index.ts
+- [ ] Export useSignaling and UseSignalingReturn from src/features/meeting/index.ts
+- [ ] Wire useSignaling into meetingLobbyPage.tsx
+
+**Shared / Cross-cutting**
+
+- [ ] Run pnpm lint and pnpm type-check with no errors
+
+**Testing**
+
+- [ ] Hook test: participant-joined creates a peer connection and emits offer via socket
+- [ ] Hook test: participant-joined with malformed payload is a no-op
+- [ ] Hook test: offer event creates PC, sets remote description, emits answer
+- [ ] Hook test: answer event calls setRemoteDescription on correct peer connection
+- [ ] Hook test: ice-candidate after setRemoteDescription is applied immediately
+- [ ] Hook test: ice-candidate before setRemoteDescription is buffered and drained after
+- [ ] Hook test: mesh limit reached -- handleParticipantJoined returns without emitting offer
+- [ ] Hook test: all listeners removed on cleanup
+- [ ] Hook test: no socket emit after isUnmountedRef is true
+- [ ] Hook test: drainIceCandidateQueue clears the queue after draining

--- a/src/features/meeting/components/meetingLobbyPage.tsx
+++ b/src/features/meeting/components/meetingLobbyPage.tsx
@@ -9,7 +9,13 @@ import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg?react';
 import CopyIcon from '@/assets/icons/copy.svg?react';
 import SpinnerIcon from '@/assets/icons/spinner.svg?react';
 import { meetingsApi } from '../services/meetingService';
-import { useMeetingSocket, useParticipants, useLocalMedia } from '../hooks';
+import {
+  useMeetingSocket,
+  useParticipants,
+  useLocalMedia,
+  usePeerConnections,
+  useSignaling,
+} from '../hooks';
 import { SOCKET_STATUS } from '../types/meeting.types';
 import type { MeetingLobbyData, ApiError } from '../types/meeting.types';
 import { ParticipantList } from './ParticipantList';
@@ -37,6 +43,11 @@ export const MeetingLobbyPage = () => {
 
   const { participants, participantCount } = useParticipants(socket, id);
   const { stream: localStream, isLoading: isMediaLoading, error: mediaError } = useLocalMedia();
+
+  const { createPeerConnection, closePeerConnection, getPeerConnection } =
+    usePeerConnections(localStream);
+
+  useSignaling(socket, id, createPeerConnection, closePeerConnection, getPeerConnection);
 
   const fetchMeetingData = useCallback(async () => {
     if (!id || !userId) return;

--- a/src/features/meeting/hooks/index.ts
+++ b/src/features/meeting/hooks/index.ts
@@ -2,3 +2,4 @@ export { useMeetingSocket } from './useMeetingSocket';
 export { useParticipants } from './useParticipants';
 export { useLocalMedia } from './useLocalMedia';
 export { usePeerConnections } from './usePeerConnections';
+export { useSignaling } from './useSignaling';

--- a/src/features/meeting/hooks/usePeerConnections.ts
+++ b/src/features/meeting/hooks/usePeerConnections.ts
@@ -135,9 +135,14 @@ export const usePeerConnections = (stream: MediaStream | null): UsePeerConnectio
     };
   }, []);
 
+  const getPeerConnection = useCallback((peerId: string): RTCPeerConnection | undefined => {
+    return peerConnectionsRef.current.get(peerId);
+  }, []);
+
   return {
     createPeerConnection,
     closePeerConnection,
+    getPeerConnection,
     peerStatuses,
     peerCount: Object.keys(peerStatuses).length,
   };

--- a/src/features/meeting/hooks/useSignaling.ts
+++ b/src/features/meeting/hooks/useSignaling.ts
@@ -1,0 +1,294 @@
+import { useState, useEffect, useRef } from 'react';
+import type { Socket } from 'socket.io-client';
+import type {
+  OfferPayload,
+  AnswerPayload,
+  IceCandidatePayload,
+  ParticipantJoinedPayload,
+  UseSignalingReturn,
+} from '../types/meeting.types';
+
+/**
+ * useSignaling — WebRTC signaling layer.
+ *
+ * Listens to socket relay events (offer, answer, ice-candidate, participant-joined)
+ * and drives RTCPeerConnection negotiation so that media can flow between participants.
+ *
+ * Peer IDs are socketIds as specified by the backend signaling protocol.
+ * All relay payloads follow the shape documented in socket-signaling.md.
+ */
+export const useSignaling = (
+  socket: Socket | null,
+  meetingId: string | undefined,
+  createPeerConnection: (peerId: string) => RTCPeerConnection | null,
+  closePeerConnection: (peerId: string) => void,
+  getPeerConnection: (peerId: string) => RTCPeerConnection | undefined,
+): UseSignalingReturn => {
+  const [isNegotiating, setIsNegotiating] = useState(false);
+  const [negotiationErrors, setNegotiationErrors] = useState<Record<string, string | null>>({});
+
+  /**
+   * Buffers RTCIceCandidateInit per peer before remote description is set.
+   * Key is socketId (peerId).
+   */
+  const iceCandidateQueuesRef = useRef<Map<string, RTCIceCandidateInit[]>>(new Map());
+
+  /**
+   * Tracks which peers have had setRemoteDescription called so ICE candidates
+   * can be applied immediately rather than buffered.
+   */
+  const remoteDescriptionSetRef = useRef<Set<string>>(new Set());
+  const isUnmountedRef = useRef<boolean>(false);
+  const socketRef = useRef<Socket | null>(null);
+  const activeNegotiationsRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!socket || !meetingId) return;
+
+    // Reset the unmount guard each time the effect runs (new socket or meetingId).
+    isUnmountedRef.current = false;
+    socketRef.current = socket;
+
+    const drainIceCandidateQueue = async (peerId: string, pc: RTCPeerConnection): Promise<void> => {
+      const queue = iceCandidateQueuesRef.current.get(peerId);
+      if (!queue?.length) return;
+      iceCandidateQueuesRef.current.delete(peerId);
+      for (const candidateInit of queue) {
+        try {
+          await pc.addIceCandidate(new RTCIceCandidate(candidateInit));
+        } catch {
+          // Ignore individual addIceCandidate failures; continue draining remaining candidates
+        }
+      }
+    };
+
+    const attachOnIceCandidate = (peerId: string, pc: RTCPeerConnection): void => {
+      pc.onicecandidate = (event: RTCPeerConnectionIceEvent) => {
+        if (isUnmountedRef.current || !event.candidate || !socketRef.current) return;
+        socketRef.current.emit('ice-candidate', {
+          meetingId,
+          targetSocketId: peerId,
+          payload: {
+            candidate: event.candidate.candidate,
+            sdpMid: event.candidate.sdpMid,
+            sdpMLineIndex: event.candidate.sdpMLineIndex,
+          },
+        });
+      };
+    };
+
+    // ── Handler: participant-joined ──────────────────────────────────────────
+    // Fired when a remote participant joins the video call room. We are the
+    // existing participant — we initiate the offer.
+    const handleParticipantJoined = async (data: ParticipantJoinedPayload): Promise<void> => {
+      const participant = data?.participant;
+      if (!participant || typeof participant.socketId !== 'string' || !participant.socketId) {
+        console.warn('[useSignaling] participant-joined: malformed payload', data);
+        return;
+      }
+
+      const peerId = participant.socketId;
+
+      // Clear stale buffers in case this peer reconnected
+      iceCandidateQueuesRef.current.delete(peerId);
+      remoteDescriptionSetRef.current.delete(peerId);
+
+      const pc = createPeerConnection(peerId);
+      if (!pc) {
+        console.warn(
+          `[useSignaling] handleParticipantJoined: could not create PC for "${peerId}" (mesh limit or error)`,
+        );
+        return;
+      }
+
+      attachOnIceCandidate(peerId, pc);
+
+      activeNegotiationsRef.current += 1;
+      setIsNegotiating(true);
+      try {
+        const offer = await pc.createOffer();
+        if (isUnmountedRef.current) return;
+        await pc.setLocalDescription(offer);
+        if (isUnmountedRef.current) return;
+        socket.emit('offer', {
+          meetingId,
+          targetSocketId: peerId,
+          payload: { type: 'offer', sdp: offer.sdp },
+        });
+      } catch (err) {
+        console.error(
+          `[useSignaling] handleParticipantJoined: offer creation failed for "${peerId}"`,
+          err,
+        );
+        closePeerConnection(peerId);
+        if (!isUnmountedRef.current) {
+          const message = err instanceof Error ? err.message : String(err);
+          setNegotiationErrors((prev) => ({ ...prev, [peerId]: message }));
+        }
+      } finally {
+        activeNegotiationsRef.current = Math.max(0, activeNegotiationsRef.current - 1);
+        if (!isUnmountedRef.current) {
+          setIsNegotiating(activeNegotiationsRef.current > 0);
+        }
+      }
+    };
+
+    // Fired when a remote participant sends us an offer. We create an answer.
+    const handleOffer = async (data: OfferPayload): Promise<void> => {
+      if (!data?.fromSocketId || typeof data.fromSocketId !== 'string') {
+        console.warn('[useSignaling] offer: malformed fromSocketId', data);
+        return;
+      }
+      if (!data.payload?.sdp || typeof data.payload.sdp !== 'string') {
+        console.warn('[useSignaling] offer: malformed payload.sdp', data);
+        return;
+      }
+
+      const peerId = data.fromSocketId;
+
+      iceCandidateQueuesRef.current.delete(peerId);
+      remoteDescriptionSetRef.current.delete(peerId);
+
+      const pc = createPeerConnection(peerId);
+      if (!pc) {
+        console.warn(
+          `[useSignaling] handleOffer: could not create PC for "${peerId}" (mesh limit or error)`,
+        );
+        return;
+      }
+
+      attachOnIceCandidate(peerId, pc);
+
+      activeNegotiationsRef.current += 1;
+      setIsNegotiating(true);
+      try {
+        await pc.setRemoteDescription(
+          new RTCSessionDescription({ type: 'offer', sdp: data.payload.sdp }),
+        );
+        if (isUnmountedRef.current) return;
+        remoteDescriptionSetRef.current.add(peerId);
+        await drainIceCandidateQueue(peerId, pc);
+        if (isUnmountedRef.current) return;
+
+        const answer = await pc.createAnswer();
+        if (isUnmountedRef.current) return;
+        await pc.setLocalDescription(answer);
+        if (isUnmountedRef.current) return;
+
+        socket.emit('answer', {
+          meetingId,
+          targetSocketId: peerId,
+          payload: { type: 'answer', sdp: answer.sdp },
+        });
+      } catch (err) {
+        console.error(`[useSignaling] handleOffer: failed for "${peerId}"`, err);
+        closePeerConnection(peerId);
+        if (!isUnmountedRef.current) {
+          const message = err instanceof Error ? err.message : String(err);
+          setNegotiationErrors((prev) => ({ ...prev, [peerId]: message }));
+        }
+      } finally {
+        activeNegotiationsRef.current = Math.max(0, activeNegotiationsRef.current - 1);
+        if (!isUnmountedRef.current) {
+          setIsNegotiating(activeNegotiationsRef.current > 0);
+        }
+      }
+    };
+
+    // Fired when the remote peer responds to our offer with an SDP answer.
+    const handleAnswer = async (data: AnswerPayload): Promise<void> => {
+      if (!data?.fromSocketId || typeof data.fromSocketId !== 'string') {
+        console.warn('[useSignaling] answer: malformed fromSocketId', data);
+        return;
+      }
+      if (!data.payload?.sdp || typeof data.payload.sdp !== 'string') {
+        console.warn('[useSignaling] answer: malformed payload.sdp', data);
+        return;
+      }
+
+      const peerId = data.fromSocketId;
+      const pc = getPeerConnection(peerId);
+      if (!pc) {
+        console.warn(`[useSignaling] handleAnswer: no peer connection for "${peerId}"`, data);
+        return;
+      }
+
+      try {
+        await pc.setRemoteDescription(
+          new RTCSessionDescription({ type: 'answer', sdp: data.payload.sdp }),
+        );
+        if (isUnmountedRef.current) return;
+        remoteDescriptionSetRef.current.add(peerId);
+        await drainIceCandidateQueue(peerId, pc);
+      } catch (err) {
+        console.error(`[useSignaling] handleAnswer: failed for "${peerId}"`, err);
+        if (!isUnmountedRef.current) {
+          const message = err instanceof Error ? err.message : String(err);
+          setNegotiationErrors((prev) => ({ ...prev, [peerId]: message }));
+        }
+      }
+    };
+
+    // Apply immediately if remote description is set; otherwise buffer.
+    const handleIceCandidate = async (data: IceCandidatePayload): Promise<void> => {
+      if (!data?.fromSocketId || typeof data.fromSocketId !== 'string') {
+        console.warn('[useSignaling] ice-candidate: malformed fromSocketId', data);
+        return;
+      }
+      if (!data.payload?.candidate || typeof data.payload.candidate !== 'string') {
+        console.warn('[useSignaling] ice-candidate: malformed payload.candidate', data);
+        return;
+      }
+
+      const peerId = data.fromSocketId;
+      const candidateInit: RTCIceCandidateInit = {
+        candidate: data.payload.candidate,
+        sdpMid: data.payload.sdpMid,
+        sdpMLineIndex: data.payload.sdpMLineIndex,
+      };
+
+      if (remoteDescriptionSetRef.current.has(peerId)) {
+        const pc = getPeerConnection(peerId);
+        if (!pc) {
+          console.warn(
+            `[useSignaling] handleIceCandidate: no PC for "${peerId}", discarding candidate`,
+          );
+          return;
+        }
+        try {
+          await pc.addIceCandidate(new RTCIceCandidate(candidateInit));
+        } catch {
+          // Ignore individual addIceCandidate failures
+        }
+      } else {
+        // Buffer the candidate until setRemoteDescription has been called for this peer
+        const queue = iceCandidateQueuesRef.current.get(peerId) ?? [];
+        queue.push(candidateInit);
+        iceCandidateQueuesRef.current.set(peerId, queue);
+      }
+    };
+
+    socket.on('participant-joined', handleParticipantJoined);
+    socket.on('offer', handleOffer);
+    socket.on('answer', handleAnswer);
+    socket.on('ice-candidate', handleIceCandidate);
+
+    // Capture current map/set in local variables so cleanup uses the same
+    // object reference even if the ref is reassigned (satisfies react-hooks/exhaustive-deps).
+    const iceCandidateQueues = iceCandidateQueuesRef.current;
+    const remoteDescriptionSet = remoteDescriptionSetRef.current;
+
+    return () => {
+      isUnmountedRef.current = true;
+      socketRef.current = null;
+      socket.off('participant-joined', handleParticipantJoined);
+      socket.off('offer', handleOffer);
+      socket.off('answer', handleAnswer);
+      socket.off('ice-candidate', handleIceCandidate);
+      iceCandidateQueues.clear();
+      remoteDescriptionSet.clear();
+    };
+  }, [socket, meetingId, createPeerConnection, closePeerConnection, getPeerConnection]);
+
+  return { isNegotiating, negotiationErrors };
+};

--- a/src/features/meeting/index.ts
+++ b/src/features/meeting/index.ts
@@ -5,7 +5,13 @@ export { LocalVideoPreview } from './components/LocalVideoPreview';
 
 export { meetingsApi } from './services/meetingService';
 export { getMeetingSocket, destroyMeetingSocket } from './services/socket';
-export { useMeetingSocket, useParticipants, useLocalMedia, usePeerConnections } from './hooks';
+export {
+  useMeetingSocket,
+  useParticipants,
+  useLocalMedia,
+  usePeerConnections,
+  useSignaling,
+} from './hooks';
 
 export { SOCKET_STATUS } from './types/meeting.types';
 
@@ -29,4 +35,8 @@ export type {
   UseLocalMediaReturn,
   PeerConnectionStatus,
   UsePeerConnectionsReturn,
+  OfferPayload,
+  AnswerPayload,
+  IceCandidatePayload,
+  UseSignalingReturn,
 } from './types/meeting.types';

--- a/src/features/meeting/types/meeting.types.ts
+++ b/src/features/meeting/types/meeting.types.ts
@@ -122,6 +122,32 @@ export type PeerConnectionStatus =
 export interface UsePeerConnectionsReturn {
   createPeerConnection: (peerId: string) => RTCPeerConnection | null;
   closePeerConnection: (peerId: string) => void;
+  getPeerConnection: (peerId: string) => RTCPeerConnection | undefined;
   peerStatuses: Record<string, PeerConnectionStatus>;
   peerCount: number;
+}
+
+/** Received when a remote peer relays an SDP offer */
+export interface OfferPayload {
+  fromSocketId: string;
+  payload: { type: 'offer'; sdp: string };
+}
+
+/** Received when a remote peer relays an SDP answer */
+export interface AnswerPayload {
+  fromSocketId: string;
+  payload: { type: 'answer'; sdp: string };
+}
+
+/** Received when a remote peer relays an ICE candidate */
+export interface IceCandidatePayload {
+  fromSocketId: string;
+  payload: { candidate: string; sdpMid: string | null; sdpMLineIndex: number | null };
+}
+
+export interface UseSignalingReturn {
+  /** True while at least one peer negotiation offer/answer round-trip is in flight */
+  isNegotiating: boolean;
+  /** Per-peer error messages; null means no error for that peer */
+  negotiationErrors: Record<string, string | null>;
 }


### PR DESCRIPTION
## References
- #17

## Description
- Add useSignaling hook for WebRTC SDP and ICE exchange
- Fix stale socket closure in attachOnIceCandidate using socketRef
- Fix isNegotiating race with activeNegotiationsRef counter
- Extend IceCandidatePayload with sdpMid and sdpMLineIndex
- Add getPeerConnection to usePeerConnections
- Wire useSignaling into meetingLobbyPage
- Add OfferPayload, AnswerPayload, UseSignalingReturn types

## Test plan
- [ ] useSignaling wired in meetingLobbyPage with no runtime errors
- [ ] offer/answer flow: participant-joined triggers offer creation
- [ ] ICE candidates include sdpMid and sdpMLineIndex
- [ ] isNegotiating stays true during concurrent negotiations
- [ ] pnpm lint and pnpm type-check pass
