### PR TITLE
feat(meeting): improve local media toggle and stream sender sync

### DIFF
--- a/src/features/meeting/components/LocalVideoPreview.tsx
+++ b/src/features/meeting/components/LocalVideoPreview.tsx
@@ -9,18 +9,29 @@ interface LocalVideoPreviewProps {
   stream: MediaStream | null;
   isLoading: boolean;
   error: string | null;
+  isCameraOn: boolean;
+  isMicrophoneOn: boolean;
 }
 
-export const LocalVideoPreview = ({ stream, isLoading, error }: LocalVideoPreviewProps) => {
+export const LocalVideoPreview = ({
+  stream,
+  isLoading,
+  error,
+  isCameraOn,
+  isMicrophoneOn,
+}: LocalVideoPreviewProps) => {
   const { t } = useTranslation();
   const videoRef = useRef<HTMLVideoElement>(null);
   const { user } = useAuth();
 
   useEffect(() => {
-    if (videoRef.current && stream) {
+    if (!videoRef.current) return;
+    if (isCameraOn && stream) {
       videoRef.current.srcObject = stream;
+    } else {
+      videoRef.current.srcObject = null;
     }
-  }, [stream]);
+  }, [stream, isCameraOn]);
 
   if (isLoading) {
     return (
@@ -32,14 +43,15 @@ export const LocalVideoPreview = ({ stream, isLoading, error }: LocalVideoPrevie
   }
 
   const isPermissionDenied = error === t('meeting.lobby.mediaPermissionDenied');
+  const showPlaceholder = !isCameraOn || isPermissionDenied || !stream;
 
   return (
-    <div className="h-64 overflow-hidden rounded-lg">
-      {isPermissionDenied ? (
+    <div className="flex min-h-64 overflow-hidden rounded-lg">
+      {showPlaceholder ? (
         <ParticipantAvatar
           displayName={user?.name ?? t('meeting.lobby.you')}
-          isMuted
-          className="h-full"
+          isMuted={!isMicrophoneOn}
+          className="flex-1"
         />
       ) : (
         <video
@@ -47,7 +59,7 @@ export const LocalVideoPreview = ({ stream, isLoading, error }: LocalVideoPrevie
           autoPlay
           playsInline
           muted
-          className="h-full w-full object-cover scale-x-[-1]"
+          className="flex-1 w-full object-cover scale-x-[-1]"
         />
       )}
     </div>

--- a/src/features/meeting/components/MediaControls.tsx
+++ b/src/features/meeting/components/MediaControls.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/shared';
 import { IconButton } from '@/components/ui';
@@ -8,6 +7,10 @@ import LeaveIcon from '@/assets/icons/leave.svg?react';
 
 interface MediaControlsProps {
   stream: MediaStream | null;
+  onToggleAudio?: () => void;
+  onToggleVideo?: () => void;
+  isAudioEnabled: boolean;
+  isVideoEnabled: boolean;
   className?: string;
   children?: React.ReactNode;
 }
@@ -33,26 +36,16 @@ const LeaveButton = ({ onLeave }: MediaControlsLeaveProps) => {
 
 export const MediaControls: React.FC<MediaControlsProps> & {
   Leave: typeof LeaveButton;
-} = ({ stream, className, children }) => {
+} = ({
+  stream,
+  className,
+  children,
+  onToggleAudio,
+  onToggleVideo,
+  isAudioEnabled,
+  isVideoEnabled,
+}) => {
   const { t } = useTranslation();
-  const [isMuted, setIsMuted] = useState(false);
-  const [isCameraOff, setIsCameraOff] = useState(false);
-
-  const toggleMic = () => {
-    if (!stream) return;
-    const track = stream.getAudioTracks()[0];
-    if (!track) return;
-    track.enabled = !isMuted;
-    setIsMuted((prev) => !prev);
-  };
-
-  const toggleCamera = () => {
-    if (!stream) return;
-    const track = stream.getVideoTracks()[0];
-    if (!track) return;
-    track.enabled = !isCameraOff;
-    setIsCameraOff((prev) => !prev);
-  };
 
   const hasAudio = stream !== null && stream.getAudioTracks().length > 0;
   const hasVideo = stream !== null && stream.getVideoTracks().length > 0;
@@ -60,15 +53,15 @@ export const MediaControls: React.FC<MediaControlsProps> & {
   return (
     <div className={cn('flex items-center justify-center gap-4', className)}>
       <IconButton
-        onClick={toggleMic}
+        onClick={onToggleAudio}
         disabled={!hasAudio}
         aria-label={t('meeting.controls.toggleMic')}
         title={t('meeting.controls.toggleMic')}
         className={cn(
           'h-12 w-12 transition-colors',
-          isMuted
-            ? 'bg-red-500 text-white hover:bg-red-600'
-            : 'bg-gray-600/80 text-white hover:bg-gray-500/80',
+          isAudioEnabled
+            ? 'bg-gray-600/80 text-white hover:bg-gray-500/80'
+            : 'bg-red-500 text-white hover:bg-red-600',
           !hasAudio && 'opacity-40 cursor-not-allowed',
         )}
       >
@@ -76,15 +69,15 @@ export const MediaControls: React.FC<MediaControlsProps> & {
       </IconButton>
 
       <IconButton
-        onClick={toggleCamera}
+        onClick={onToggleVideo}
         disabled={!hasVideo}
         aria-label={t('meeting.controls.toggleCamera')}
         title={t('meeting.controls.toggleCamera')}
         className={cn(
           'h-12 w-12 transition-colors',
-          isCameraOff
-            ? 'bg-red-500 text-white hover:bg-red-600'
-            : 'bg-gray-600/80 text-white hover:bg-gray-500/80',
+          isVideoEnabled
+            ? 'bg-gray-600/80 text-white hover:bg-gray-500/80'
+            : 'bg-red-500 text-white hover:bg-red-600',
           !hasVideo && 'opacity-40 cursor-not-allowed',
         )}
       >

--- a/src/features/meeting/components/MeetingPage.tsx
+++ b/src/features/meeting/components/MeetingPage.tsx
@@ -80,7 +80,17 @@ export const MeetingPage = () => {
     fetchMeetingData();
   }, [id, navigate, fetchMeetingData]);
 
-  const { stream: localStream, isLoading: isMediaLoading, error: mediaError } = useLocalMedia();
+  const {
+    stream: localStream,
+    isLoading: isMediaLoading,
+    error: mediaError,
+    toggleAudio,
+    toggleVideo,
+    isAudioEnabled,
+    isVideoEnabled,
+    videoSendersRef,
+    audioSendersRef,
+  } = useLocalMedia();
 
   const {
     socket,
@@ -97,7 +107,7 @@ export const MeetingPage = () => {
   const { participants, participantCount } = useParticipants(socket, id);
 
   const { createPeerConnection, closePeerConnection, getPeerConnection, peerStatuses } =
-    usePeerConnections(localStream);
+    usePeerConnections(localStream, videoSendersRef, audioSendersRef);
 
   const { remoteStreams, addStream } = useRemoteStreams(getPeerConnection, peerStatuses);
 
@@ -155,6 +165,8 @@ export const MeetingPage = () => {
         stream: localStream,
         label: user?.name ?? t('meeting.start.youLabel'),
         isLocal: true,
+        isCameraOff: !isVideoEnabled,
+        isMuted: !isAudioEnabled,
       },
     ];
 
@@ -168,7 +180,16 @@ export const MeetingPage = () => {
     }
 
     return result;
-  }, [phase, localStream, remoteStreams, participants, user?.name, t]);
+  }, [
+    phase,
+    localStream,
+    remoteStreams,
+    participants,
+    user?.name,
+    t,
+    isVideoEnabled,
+    isAudioEnabled,
+  ]);
 
   const copyMeetingId = () => {
     if (!id) return;
@@ -275,9 +296,17 @@ export const MeetingPage = () => {
                   stream={localStream}
                   isLoading={isMediaLoading}
                   error={mediaError}
+                  isCameraOn={isVideoEnabled}
+                  isMicrophoneOn={isAudioEnabled}
                 />
                 <div className="mt-4 flex justify-center">
-                  <MediaControls stream={localStream} />
+                  <MediaControls
+                    stream={localStream}
+                    onToggleAudio={toggleAudio}
+                    onToggleVideo={toggleVideo}
+                    isAudioEnabled={isAudioEnabled}
+                    isVideoEnabled={isVideoEnabled}
+                  />
                 </div>
               </div>
 
@@ -356,7 +385,13 @@ export const MeetingPage = () => {
 
       <div className="absolute bottom-0 left-0 right-0 z-20 flex items-center justify-center py-5 pointer-events-none">
         <div className="pointer-events-auto flex items-center gap-6 rounded-full bg-gray-800/70 backdrop-blur-md px-6 py-3 shadow-lg ring-1 ring-white/10">
-          <MediaControls stream={localStream}>
+          <MediaControls
+            stream={localStream}
+            onToggleAudio={toggleAudio}
+            onToggleVideo={toggleVideo}
+            isAudioEnabled={isAudioEnabled}
+            isVideoEnabled={isVideoEnabled}
+          >
             <MediaControls.Leave onLeave={handleLeave} />
           </MediaControls>
 

--- a/src/features/meeting/components/ParticipantAvatar.tsx
+++ b/src/features/meeting/components/ParticipantAvatar.tsx
@@ -24,7 +24,7 @@ export const ParticipantAvatar = ({
   return (
     <div
       className={cn(
-        'relative flex items-center flex-1 justify-center w-full h-full overflow-hidden',
+        'relative flex items-center flex-1 justify-center w-full overflow-hidden',
         'bg-linear-to-br',
         background,
         className,

--- a/src/features/meeting/hooks/useLocalMedia.ts
+++ b/src/features/meeting/hooks/useLocalMedia.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import type { UseLocalMediaReturn } from '../types/meeting.types';
 import { useTranslation } from 'react-i18next';
 
@@ -26,21 +26,21 @@ export const useLocalMedia = (): UseLocalMediaReturn => {
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isAudioEnabled, setIsAudioEnabled] = useState(false);
+  const [isVideoEnabled, setIsVideoEnabled] = useState(false);
 
-  const isMountedRef = useRef<boolean>(false);
   const streamRef = useRef<MediaStream | null>(null);
-
+  const videoSendersRef = useRef<Set<RTCRtpSender>>(new Set());
+  const audioSendersRef = useRef<Set<RTCRtpSender>>(new Set());
   const { t } = useTranslation();
 
   useEffect(() => {
-    isMountedRef.current = true;
+    let cancelled = false;
 
     const acquire = async () => {
       if (!navigator.mediaDevices?.getUserMedia) {
-        if (isMountedRef.current) {
-          setError(t(MEDIA_ERROR_KEYS.GENERIC));
-          setIsLoading(false);
-        }
+        setError(t(MEDIA_ERROR_KEYS.GENERIC));
+        setIsLoading(false);
         return;
       }
 
@@ -50,18 +50,30 @@ export const useLocalMedia = (): UseLocalMediaReturn => {
           audio: true,
         });
 
-        if (!isMountedRef.current) {
-          // Component unmounted before promise resolved — stop tracks immediately
+        if (cancelled) {
           mediaStream.getTracks().forEach((track) => track.stop());
           return;
         }
 
         streamRef.current = mediaStream;
 
+        const videoEnabled = mediaStream.getVideoTracks().some((t) => t.enabled);
+        const audioEnabled = mediaStream.getAudioTracks().some((t) => t.enabled);
+
+        setIsVideoEnabled(videoEnabled);
+        setIsAudioEnabled(audioEnabled);
+
+        mediaStream.getVideoTracks().forEach((track) => {
+          track.onended = () => setIsVideoEnabled(false);
+        });
+        mediaStream.getAudioTracks().forEach((track) => {
+          track.onended = () => setIsAudioEnabled(false);
+        });
+
         setStream(mediaStream);
         setIsLoading(false);
       } catch (err) {
-        if (!isMountedRef.current) return;
+        if (cancelled) return;
         setError(resolveMediaErrorKey(err, t));
         setIsLoading(false);
       }
@@ -70,11 +82,92 @@ export const useLocalMedia = (): UseLocalMediaReturn => {
     void acquire();
 
     return () => {
-      isMountedRef.current = false;
+      cancelled = true;
+
       streamRef.current?.getTracks().forEach((track) => track.stop());
       streamRef.current = null;
     };
+  }, [t]);
+
+  const toggleAudio = useCallback(() => {
+    const tracks = streamRef.current?.getAudioTracks() ?? [];
+    if (!tracks.length) return;
+
+    const next = !tracks[0].enabled;
+
+    tracks.forEach((track) => {
+      track.enabled = next;
+    });
+
+    setIsAudioEnabled(next);
   }, []);
 
-  return { stream, isLoading, error };
+  const toggleVideo = useCallback(async () => {
+    const currentStream = streamRef.current;
+    if (!currentStream) return;
+
+    const liveVideoTrack = currentStream
+      .getVideoTracks()
+      .find((track) => track.readyState === 'live');
+
+    if (liveVideoTrack) {
+      // Turn OFF: stop track to release camera hardware (LED turns off)
+      liveVideoTrack.stop();
+
+      // Stop sending video to all peers
+      const promises: Promise<void>[] = [];
+      for (const sender of videoSendersRef.current) {
+        promises.push(sender.replaceTrack(null));
+      }
+      await Promise.all(promises);
+
+      setIsVideoEnabled(false);
+    } else {
+      // Turn ON: acquire a new video track
+      try {
+        const newMediaStream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+        });
+        const newVideoTrack = newMediaStream.getVideoTracks()[0];
+
+        // Remove ended video tracks from the existing stream
+        currentStream.getVideoTracks().forEach((track) => {
+          currentStream.removeTrack(track);
+        });
+
+        // Add the new live track into the existing MediaStream
+        currentStream.addTrack(newVideoTrack);
+
+        // Resume sending video to all peers
+        const promises: Promise<void>[] = [];
+        for (const sender of videoSendersRef.current) {
+          promises.push(sender.replaceTrack(newVideoTrack));
+        }
+        await Promise.all(promises);
+
+        newVideoTrack.onended = () => setIsVideoEnabled(false);
+
+        setIsVideoEnabled(true);
+
+        // Force React re-render with a new MediaStream reference
+        const updated = new MediaStream(currentStream.getTracks());
+        streamRef.current = updated;
+        setStream(updated);
+      } catch (err) {
+        setError(resolveMediaErrorKey(err, t));
+      }
+    }
+  }, [t]);
+
+  return {
+    stream,
+    isLoading,
+    error,
+    toggleAudio,
+    toggleVideo,
+    isAudioEnabled,
+    isVideoEnabled,
+    videoSendersRef,
+    audioSendersRef,
+  };
 };

--- a/src/features/meeting/hooks/useMeetingSocket.ts
+++ b/src/features/meeting/hooks/useMeetingSocket.ts
@@ -104,6 +104,8 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
     isUnmountedRef.current = false;
 
     const sock = getMeetingSocket(env.socketUrl, accessToken);
+    console.log('SOCK', sock);
+
     socketRef.current = sock;
 
     /**

--- a/src/features/meeting/hooks/usePeerConnections.ts
+++ b/src/features/meeting/hooks/usePeerConnections.ts
@@ -5,7 +5,11 @@ import type { PeerConnectionStatus, UsePeerConnectionsReturn } from '../types/me
 const MAX_PEER_CONNECTIONS = 3;
 const DEFAULT_STUN = 'stun:stun.l.google.com:19302';
 let stunWarnedOnce = false;
-export const usePeerConnections = (stream: MediaStream | null): UsePeerConnectionsReturn => {
+export const usePeerConnections = (
+  stream: MediaStream | null,
+  videoSendersRef?: { current: Set<RTCRtpSender> },
+  audioSendersRef?: { current: Set<RTCRtpSender> },
+): UsePeerConnectionsReturn => {
   const peerConnectionsRef = useRef<Map<string, RTCPeerConnection>>(new Map());
   const [peerStatuses, setPeerStatuses] = useState<Record<string, PeerConnectionStatus>>({});
   const isUnmountedRef = useRef<boolean>(false);
@@ -23,7 +27,11 @@ export const usePeerConnections = (stream: MediaStream | null): UsePeerConnectio
       if (map.has(peerId)) {
         const existing = map.get(peerId)!;
         try {
-          existing.getSenders().forEach((s) => existing.removeTrack(s));
+          existing.getSenders().forEach((s) => {
+            videoSendersRef?.current.delete(s);
+            audioSendersRef?.current.delete(s);
+            existing.removeTrack(s);
+          });
           existing.close();
         } catch (err) {
           console.warn(
@@ -65,9 +73,13 @@ export const usePeerConnections = (stream: MediaStream | null): UsePeerConnectio
 
       const pc = new RTCPeerConnection({ iceServers: [{ urls: stunUrl }] });
 
-      // Add local tracks
+      // Add local tracks and register senders
       if (stream !== null) {
-        stream.getTracks().forEach((track) => pc.addTrack(track, stream));
+        stream.getTracks().forEach((track) => {
+          const sender = pc.addTrack(track, stream);
+          if (track.kind === 'video') videoSendersRef?.current.add(sender);
+          else if (track.kind === 'audio') audioSendersRef?.current.add(sender);
+        });
       }
 
       // Track connection state changes
@@ -87,43 +99,54 @@ export const usePeerConnections = (stream: MediaStream | null): UsePeerConnectio
 
       return pc;
     },
-    [stream],
+    [stream, videoSendersRef, audioSendersRef],
   );
 
-  const closePeerConnection = useCallback((peerId: string): void => {
-    const map = peerConnectionsRef.current;
-    const pc = map.get(peerId);
-    if (!pc) return;
+  const closePeerConnection = useCallback(
+    (peerId: string): void => {
+      const map = peerConnectionsRef.current;
+      const pc = map.get(peerId);
+      if (!pc) return;
 
-    pc.getSenders().forEach((s) => {
+      pc.getSenders().forEach((s) => {
+        videoSendersRef?.current.delete(s);
+        audioSendersRef?.current.delete(s);
+        try {
+          pc.removeTrack(s);
+        } catch (err) {
+          console.warn(`[usePeerConnections] removeTrack error for "${peerId}":`, err);
+        }
+      });
+
       try {
-        pc.removeTrack(s);
+        pc.close();
       } catch (err) {
-        console.warn(`[usePeerConnections] removeTrack error for "${peerId}":`, err);
+        console.error(`[usePeerConnections] pc.close() error for "${peerId}":`, err);
       }
-    });
 
-    try {
-      pc.close();
-    } catch (err) {
-      console.error(`[usePeerConnections] pc.close() error for "${peerId}":`, err);
-    }
+      map.delete(peerId);
 
-    map.delete(peerId);
-
-    setPeerStatuses((prev) => {
-      const next = { ...prev };
-      delete next[peerId];
-      return next;
-    });
-  }, []);
+      setPeerStatuses((prev) => {
+        const next = { ...prev };
+        delete next[peerId];
+        return next;
+      });
+    },
+    [videoSendersRef, audioSendersRef],
+  );
 
   // Cleanup: close all peer connections on unmount
   useEffect(() => {
     const map = peerConnectionsRef.current;
+    const videoSenders = videoSendersRef?.current;
+    const audioSenders = audioSendersRef?.current;
     return () => {
       isUnmountedRef.current = true;
       map.forEach((pc) => {
+        pc.getSenders().forEach((s) => {
+          videoSenders?.delete(s);
+          audioSenders?.delete(s);
+        });
         try {
           pc.close();
         } catch {
@@ -133,7 +156,7 @@ export const usePeerConnections = (stream: MediaStream | null): UsePeerConnectio
       map.clear();
       setPeerStatuses({});
     };
-  }, []);
+  }, [videoSendersRef, audioSendersRef]);
 
   const getPeerConnection = useCallback((peerId: string): RTCPeerConnection | undefined => {
     return peerConnectionsRef.current.get(peerId);

--- a/src/features/meeting/types/meeting.types.ts
+++ b/src/features/meeting/types/meeting.types.ts
@@ -91,6 +91,12 @@ export interface UseLocalMediaReturn {
   stream: MediaStream | null;
   isLoading: boolean;
   error: string | null;
+  toggleAudio: () => void;
+  toggleVideo: () => Promise<void>;
+  isAudioEnabled: boolean;
+  isVideoEnabled: boolean;
+  videoSendersRef: { current: Set<RTCRtpSender> };
+  audioSendersRef: { current: Set<RTCRtpSender> };
 }
 
 export type PeerConnectionStatus =


### PR DESCRIPTION
## Description
- Implement Google Meet–style camera toggle in useLocalMedia
- OFF: stop video track, replace RTCRtpSender with null, preserve active stream
- ON: get new video track, replace sender track, update stream state
- Add usePeerConnections sender registration and cleanup
- Make LocalVideoPreview reattach/detach video element srcObject based on isCameraOn
- Add isCameraOff and isMuted flags for local tile

## Test plan
- [ ] Toggle camera OFF -> participant avatar appears and camera LED off
- [ ] Toggle camera ON -> video resumes and no black screen
- [ ] Toggle audio mute/unmute works
- [ ] Lint passes