### PR TITLE
fix(meeting): ensure media state sync and frozen remote video resolved

### DIFF
--- a/src/features/meeting/components/MeetingPage.tsx
+++ b/src/features/meeting/components/MeetingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/features/auth';
@@ -24,17 +24,6 @@ import { LocalVideoPreview } from './LocalVideoPreview';
 import { ParticipantList } from './ParticipantList';
 import { MeetingPhase, MeetingPhaseFlags } from '@/shared/constants/meeting';
 
-/**
- * Unified meeting page with a phase state machine:
- *
- *   PRE_JOIN  →  user sees lobby, local media preview, Join button
- *   JOINING   →  connecting socket + emitting join-room
- *   IN_CALL   →  full video grid with WebRTC
- *
- * Socket is created on page load (after meeting metadata loads) so we can
- * observe lobby presence via watch-meeting, but the user only enters the call
- * (join-room) after clicking Join.
- */
 export const MeetingPage = () => {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
@@ -92,6 +81,15 @@ export const MeetingPage = () => {
     audioSendersRef,
   } = useLocalMedia();
 
+  const isVideoEnabledRef = useRef(isVideoEnabled);
+  const isAudioEnabledRef = useRef(isAudioEnabled);
+  useEffect(() => {
+    isVideoEnabledRef.current = isVideoEnabled;
+  }, [isVideoEnabled]);
+  useEffect(() => {
+    isAudioEnabledRef.current = isAudioEnabled;
+  }, [isAudioEnabled]);
+
   const {
     socket,
     connect,
@@ -121,9 +119,83 @@ export const MeetingPage = () => {
 
   useEffect(() => {
     if (!pendingJoin || !socket) return;
+    if (!socket.connected) {
+      return;
+    }
     setPendingJoin(false);
     joinRoom();
+    // Do NOT emit participant-media-state here — it races the server’s async
+    // join-room handler. The participants-confirm effect below emits it once
+    // the server confirms our join via participants-list.
   }, [pendingJoin, socket, joinRoom]);
+
+  // Centralised emit helper. Guards against:
+  //   socket being null / disconnected (prevents silent drops)
+  //   emitting before the user has formally joined the room (lobby phase)
+  const safeEmitMediaState = useCallback(
+    (video: boolean, audio: boolean) => {
+      if (!socket?.connected) return;
+      if (!MeetingPhaseFlags.isInCall(phase)) {
+        // Socket is connected via watch-meeting in the lobby but the user
+        // hasn’t joined the room yet — the server would reject the event.
+        return;
+      }
+      const payload = { meetingId: id, video, audio };
+      socket.emit('participant-media-state', payload);
+    },
+    [socket, phase, id],
+  );
+
+  // Reset flag when the socket disconnects so the initial emit fires again
+  // after reconnect (server resets media defaults when the socket rejoins).
+  const hasEmittedInitialMediaStateRef = useRef(false);
+  useEffect(() => {
+    if (!isConnected) {
+      hasEmittedInitialMediaStateRef.current = false;
+    }
+  }, [isConnected]);
+
+  // Emit our initial media state once the server confirms we are in the room,
+  // detected by seeing our own userId appear in participants-list.
+  // This serialises the emit AFTER the server’s async join-room handler,
+  // eliminating the race where participant-media-state arrives before the
+  // socket has been added to the room. Also handles post-reconnect rejoin.
+  useEffect(() => {
+    if (!MeetingPhaseFlags.isInCall(phase)) return;
+    if (hasEmittedInitialMediaStateRef.current) return;
+    if (!socket?.connected) return;
+    if (!userId) return;
+
+    const selfInRoom = participants.some((p) => p.userId === userId);
+    if (!selfInRoom) return;
+
+    hasEmittedInitialMediaStateRef.current = true;
+    const payload = {
+      meetingId: id,
+      video: isVideoEnabledRef.current,
+      audio: isAudioEnabledRef.current,
+    };
+
+    socket.emit('participant-media-state', payload);
+  }, [participants, phase, socket, userId, id]);
+
+  // Toggle handlers: toggle local media then broadcast the new state.
+  // Using refs to read current state avoids stale closures in async callbacks.
+  const handleToggleVideo = useCallback(async () => {
+    const nextVideo = !isVideoEnabledRef.current;
+    await toggleVideo();
+    // Update ref eagerly so a concurrent handleToggleAudio reads correct value.
+    isVideoEnabledRef.current = nextVideo;
+    safeEmitMediaState(nextVideo, isAudioEnabledRef.current);
+  }, [toggleVideo, safeEmitMediaState]);
+
+  const handleToggleAudio = useCallback(() => {
+    const nextAudio = !isAudioEnabledRef.current;
+    toggleAudio();
+    // Update ref eagerly so a concurrent handleToggleVideo reads correct value.
+    isAudioEnabledRef.current = nextAudio;
+    safeEmitMediaState(isVideoEnabledRef.current, nextAudio);
+  }, [toggleAudio, safeEmitMediaState]);
 
   // Once meeting metadata is loaded, connect the socket in the background and
   // emit watch-meeting so the lobby shows real-time participant presence
@@ -170,12 +242,19 @@ export const MeetingPage = () => {
       },
     ];
 
-    for (const [peerId, stream] of remoteStreams) {
-      const participant = participants.find((p) => p.socketId === peerId);
+    // Build remote tiles from the participant list so tiles appear immediately
+    // when a participant joins, even before their camera stream arrives.
+    // isCameraOff/isMuted come from signaling state, NOT stream inspection.
+    for (const participant of participants) {
+      if (participant.userId === userId) continue;
+      const peerId = participant.socketId;
+      const stream = remoteStreams.get(peerId) ?? null;
       result.push({
         peerId,
         stream,
-        label: participant?.name ?? peerId,
+        label: participant.name ?? peerId,
+        isCameraOff: participant.isVideoEnabled === false,
+        isMuted: participant.isAudioEnabled === false,
       });
     }
 
@@ -189,6 +268,7 @@ export const MeetingPage = () => {
     t,
     isVideoEnabled,
     isAudioEnabled,
+    userId,
   ]);
 
   const copyMeetingId = () => {
@@ -302,8 +382,8 @@ export const MeetingPage = () => {
                 <div className="mt-4 flex justify-center">
                   <MediaControls
                     stream={localStream}
-                    onToggleAudio={toggleAudio}
-                    onToggleVideo={toggleVideo}
+                    onToggleAudio={handleToggleAudio}
+                    onToggleVideo={handleToggleVideo}
                     isAudioEnabled={isAudioEnabled}
                     isVideoEnabled={isVideoEnabled}
                   />
@@ -387,8 +467,8 @@ export const MeetingPage = () => {
         <div className="pointer-events-auto flex items-center gap-6 rounded-full bg-gray-800/70 backdrop-blur-md px-6 py-3 shadow-lg ring-1 ring-white/10">
           <MediaControls
             stream={localStream}
-            onToggleAudio={toggleAudio}
-            onToggleVideo={toggleVideo}
+            onToggleAudio={handleToggleAudio}
+            onToggleVideo={handleToggleVideo}
             isAudioEnabled={isAudioEnabled}
             isVideoEnabled={isVideoEnabled}
           >

--- a/src/features/meeting/components/VideoGrid.tsx
+++ b/src/features/meeting/components/VideoGrid.tsx
@@ -6,48 +6,60 @@ import { ParticipantAvatar } from './ParticipantAvatar';
 
 interface TileProps {
   tile: VideoTile;
-  /** When true the tile is the only one — it fills the entire container. */
-  solo?: boolean;
 }
 
-const Tile = ({ tile, solo = false }: TileProps) => {
+const Tile = ({ tile }: TileProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  const hasVideo =
+    !tile.isCameraOff && tile.stream !== null && tile.stream.getVideoTracks().length > 0;
 
   useEffect(() => {
     const el = videoRef.current;
     if (!el) return;
-    el.srcObject = tile.stream;
-  }, [tile.stream]);
 
-  const wrapperClass = cn(
-    'relative overflow-hidden rounded-xl bg-gray-800',
-    solo && 'w-full h-full',
-  );
+    if (hasVideo && tile.stream) {
+      el.srcObject = tile.stream;
+    } else {
+      el.srcObject = null;
+    }
 
-  if (tile.isCameraOff || !tile.stream) {
-    return (
-      <ParticipantAvatar displayName={tile.label} isMuted={tile.isMuted} className={wrapperClass} />
-    );
-  }
+    return () => {
+      if (el) el.srcObject = null;
+    };
+  }, [hasVideo, tile.stream]);
 
   return (
-    <div className={wrapperClass}>
+    <div className="relative w-full h-full overflow-hidden rounded-xl bg-gray-800">
+      <ParticipantAvatar
+        displayName={tile.label}
+        isMuted={tile.isMuted}
+        className="absolute inset-0"
+      />
+
       <video
         ref={videoRef}
         autoPlay
         playsInline
         muted={tile.isLocal}
-        className={cn('w-full h-full object-cover', tile.isLocal && 'scale-x-[-1]')}
+        className={cn(
+          'absolute inset-0 w-full h-full object-cover',
+          tile.isLocal && 'scale-x-[-1]',
+          !hasVideo && 'hidden',
+        )}
       />
 
-      <span className="absolute bottom-3 left-3 text-xs text-white/90 bg-black/50 backdrop-blur-sm px-2.5 py-1 rounded-md">
-        {tile.label}
-      </span>
-
-      {tile.isMuted && (
-        <span className="absolute top-3 right-3 bg-black/50 backdrop-blur-sm rounded-full p-1">
-          <MicOffIcon className="w-4 h-4 text-red-400" />
-        </span>
+      {hasVideo && (
+        <>
+          <span className="absolute bottom-3 left-3 text-xs text-white/90 bg-black/50 backdrop-blur-sm px-2.5 py-1 rounded-md">
+            {tile.label}
+          </span>
+          {tile.isMuted && (
+            <span className="absolute top-3 right-3 bg-black/50 backdrop-blur-sm rounded-full p-1">
+              <MicOffIcon className="w-4 h-4 text-red-400" />
+            </span>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/features/meeting/hooks/useParticipants.ts
+++ b/src/features/meeting/hooks/useParticipants.ts
@@ -5,6 +5,7 @@ import type {
   ParticipantJoinedPayload,
   ParticipantLeftPayload,
   ParticipantsListPayload,
+  ParticipantMediaStatePayload,
   UseParticipantsReturn,
 } from '../types/meeting.types';
 
@@ -35,7 +36,7 @@ export const useParticipants = (
       const map: Record<string, ParticipantInfo> = {};
 
       for (const p of payload.participants) {
-        map[p.userId] = p; // key by userId to deduplicate reconnects
+        map[p.userId] = p;
       }
       setParticipantMap(map);
     };
@@ -43,10 +44,6 @@ export const useParticipants = (
     const handleParticipantJoined = (payload: ParticipantJoinedPayload) => {
       const participant = payload?.participant;
       if (!participant || typeof participant.userId !== 'string' || !participant.userId) {
-        console.warn(
-          '[useParticipants] participant-joined: malformed payload — missing or invalid participant.userId',
-          payload,
-        );
         return;
       }
 
@@ -59,19 +56,11 @@ export const useParticipants = (
     const handleParticipantLeft = (payload: ParticipantLeftPayload) => {
       const participant = payload?.participant;
       if (!participant || typeof participant.userId !== 'string' || !participant.userId) {
-        console.warn(
-          '[useParticipants] participant-left: malformed payload — missing or invalid participant.userId',
-          payload,
-        );
         return;
       }
 
       const { userId } = participant;
       if (!participantMapRef.current[userId]) {
-        console.warn(
-          '[useParticipants] participant-left: userId not found in map, treating as no-op',
-          userId,
-        );
         return;
       }
       setParticipantMap((prev) => {
@@ -81,14 +70,33 @@ export const useParticipants = (
       });
     };
 
+    const handleMediaState = (payload: ParticipantMediaStatePayload) => {
+      if (!payload || typeof payload.userId !== 'string' || !payload.userId) {
+        return;
+      }
+
+      const { userId, video, audio } = payload;
+      setParticipantMap((prev) => {
+        if (!prev[userId]) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [userId]: { ...prev[userId], isVideoEnabled: video, isAudioEnabled: audio },
+        };
+      });
+    };
+
     socket.on('participants-list', handleParticipantsList);
     socket.on('participant-joined', handleParticipantJoined);
     socket.on('participant-left', handleParticipantLeft);
+    socket.on('participant-media-state', handleMediaState);
 
     return () => {
       socket.off('participants-list', handleParticipantsList);
       socket.off('participant-joined', handleParticipantJoined);
       socket.off('participant-left', handleParticipantLeft);
+      socket.off('participant-media-state', handleMediaState);
 
       setParticipantMap({});
     };

--- a/src/features/meeting/types/meeting.types.ts
+++ b/src/features/meeting/types/meeting.types.ts
@@ -55,6 +55,17 @@ export interface ParticipantInfo {
   name: string;
   isHost: boolean;
   joinedAt: number;
+  /** Reflects the remote participant's camera state, driven by signaling. Defaults to true (server assumes camera ON on join). */
+  isVideoEnabled: boolean;
+  /** Reflects the remote participant's microphone state, driven by signaling. Defaults to true (server assumes mic ON on join). */
+  isAudioEnabled: boolean;
+}
+
+export interface ParticipantMediaStatePayload {
+  meetingId: string;
+  userId: string;
+  video: boolean;
+  audio: boolean;
 }
 
 /** Client → Server: join the active video call */


### PR DESCRIPTION
## Description

- Fix media state synchronization by treating participant state as the single source of truth:
  - `isVideoEnabled`
  - `isAudioEnabled`  
  Applied across participant list and tile rendering.

- Add `safeEmitMediaState` guard:
  - Emits events **only when socket is connected and user is in-call**
  - Always includes both **video** and **audio** state values

- Resolve frozen remote video issue:
  - Keep `<video>` element mounted in the DOM
  - Reset `srcObject` when camera is turned off

- Add `participant-media-state` handler in `useParticipants`:
  - Perform **immutable state updates**
  - Ensure proper re-rendering

- **Affected modules:**
  - `MeetingPage`
  - `useParticipants`
  - `VideoGrid`
  - `meeting.types`

---

## Test Plan

- [ ] Join a meeting  
- [ ] Toggle camera and microphone  
- [ ] Verify participant tiles and avatars update in real time for remote users  
- [ ] Confirm backend receives `participant-media-state` events on each toggle (via server logs)
- [ ] Verify there are **no frozen/stale video frames** after remote camera is turned off and back on