### PR TITLE
feat(meeting): add toast notification system

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "i18next": "^25.8.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-hot-toast": "^2.6.0",
     "react-i18next": "^16.5.4",
     "react-router-dom": "^7.12.0",
     "socket.io-client": "^4.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.3(react@19.2.3)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-i18next:
         specifier: ^16.5.4
         version: 16.5.4(i18next@25.8.1(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -1323,6 +1326,11 @@ packages:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
+  goober@2.1.18:
+    resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1685,6 +1693,13 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-i18next@16.5.4:
     resolution: {integrity: sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g==}
@@ -3122,6 +3137,10 @@ snapshots:
 
   globals@16.5.0: {}
 
+  goober@2.1.18(csstype@3.2.3):
+    dependencies:
+      csstype: 3.2.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -3417,6 +3436,13 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-hot-toast@2.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      csstype: 3.2.3
+      goober: 2.1.18(csstype@3.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-i18next@16.5.4(i18next@25.8.1(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
     dependencies:

--- a/src/assets/icons/info-circle.svg
+++ b/src/assets/icons/info-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/>
+</svg>

--- a/src/features/meeting/components/MeetingPage.tsx
+++ b/src/features/meeting/components/MeetingPage.tsx
@@ -11,10 +11,12 @@ import {
   useLocalMedia,
   useMeetingSocket,
   useParticipants,
+  useParticipantToasts,
   usePeerConnections,
   useSignaling,
   useRemoteStreams,
 } from '../hooks';
+import { showToast } from '@/shared/utils/toast';
 import { meetingsApi } from '../services/meetingService';
 import { SOCKET_STATUS } from '../types/meeting.types';
 import type { Meeting, ApiError, VideoTile } from '../types/meeting.types';
@@ -109,7 +111,16 @@ export const MeetingPage = () => {
 
   const { remoteStreams, addStream } = useRemoteStreams(getPeerConnection, peerStatuses);
 
-  useSignaling(socket, id, createPeerConnection, closePeerConnection, getPeerConnection, addStream);
+  const { negotiationErrors } = useSignaling(
+    socket,
+    id,
+    createPeerConnection,
+    closePeerConnection,
+    getPeerConnection,
+    addStream,
+  );
+
+  useParticipantToasts(socket, phase, userId);
 
   // pendingJoin is set to true by handleJoin and consumed by the effect below.
   // This decouples joinRoom() from the connect() call, ensuring useSignaling's
@@ -220,8 +231,9 @@ export const MeetingPage = () => {
       setPhase(MeetingPhase.IN_CALL);
     } catch {
       setPhase(MeetingPhase.PRE_JOIN);
+      showToast.error(t('meeting.toast.joinFailed'), 'join-failed');
     }
-  }, [connect]);
+  }, [connect, t]);
 
   const handleLeave = useCallback(() => {
     leaveRoom();
@@ -274,7 +286,28 @@ export const MeetingPage = () => {
   const copyMeetingId = () => {
     if (!id) return;
     navigator.clipboard.writeText(id);
+    showToast.success(t('meeting.toast.roomIdCopied'), 'copy-room-id');
   };
+
+  // Show toast when media permission is denied or device not found
+  const prevMediaErrorRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (mediaError && mediaError !== prevMediaErrorRef.current) {
+      showToast.error(mediaError, 'media-error');
+    }
+    prevMediaErrorRef.current = mediaError;
+  }, [mediaError]);
+
+  // Show toast for WebRTC negotiation errors
+  const prevNegotiationErrorsRef = useRef<Record<string, string | null>>({});
+  useEffect(() => {
+    for (const [peerId, message] of Object.entries(negotiationErrors)) {
+      if (message && prevNegotiationErrorsRef.current[peerId] !== message) {
+        showToast.error(t('meeting.toast.webrtcError'), `webrtc-${peerId}`);
+      }
+    }
+    prevNegotiationErrorsRef.current = negotiationErrors;
+  }, [negotiationErrors, t]);
 
   if (MeetingPhaseFlags.isPreJoin(phase) || MeetingPhaseFlags.isJoining(phase)) {
     if (isLoading) {

--- a/src/features/meeting/hooks/index.ts
+++ b/src/features/meeting/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useMeetingSocket } from './useMeetingSocket';
 export { useParticipants } from './useParticipants';
+export { useParticipantToasts } from './useParticipantToasts';
 export { useLocalMedia } from './useLocalMedia';
 export { usePeerConnections } from './usePeerConnections';
 export { useSignaling } from './useSignaling';

--- a/src/features/meeting/hooks/useMeetingSocket.ts
+++ b/src/features/meeting/hooks/useMeetingSocket.ts
@@ -104,7 +104,6 @@ export const useMeetingSocket = (meetingId: string | undefined): UseMeetingSocke
     isUnmountedRef.current = false;
 
     const sock = getMeetingSocket(env.socketUrl, accessToken);
-    console.log('SOCK', sock);
 
     socketRef.current = sock;
 

--- a/src/features/meeting/hooks/useParticipantToasts.ts
+++ b/src/features/meeting/hooks/useParticipantToasts.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+import type { Socket } from 'socket.io-client';
+import { useTranslation } from 'react-i18next';
+import { showToast } from '@/shared/utils/toast';
+import { MeetingPhase, MeetingPhaseFlags } from '@/shared/constants/meeting';
+import type { ParticipantJoinedPayload, ParticipantLeftPayload } from '../types/meeting.types';
+
+/**
+ * Shows toast notifications when participants join or leave the meeting.
+ *
+ * Only fires while the current user is IN_CALL (not during lobby/watch-meeting).
+ * Uses toast IDs to prevent duplicate notifications for the same event.
+ */
+export const useParticipantToasts = (
+  socket: Socket | null,
+  phase: MeetingPhase,
+  currentUserId: string | undefined,
+): void => {
+  const { t } = useTranslation();
+  const phaseRef = useRef(phase);
+  const currentUserIdRef = useRef(currentUserId);
+
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+
+  useEffect(() => {
+    currentUserIdRef.current = currentUserId;
+  }, [currentUserId]);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleJoined = (payload: ParticipantJoinedPayload) => {
+      if (!MeetingPhaseFlags.isInCall(phaseRef.current)) return;
+
+      const participant = payload?.participant;
+      if (!participant || participant.userId === currentUserIdRef.current) return;
+
+      const name = participant.name ?? participant.userId;
+      showToast.success(t('meeting.toast.userJoined', { name }), `join-${participant.userId}`);
+    };
+
+    const handleLeft = (payload: ParticipantLeftPayload) => {
+      if (!MeetingPhaseFlags.isInCall(phaseRef.current)) return;
+
+      const participant = payload?.participant;
+      if (!participant || participant.userId === currentUserIdRef.current) return;
+
+      const name = participant.name ?? participant.userId;
+      showToast.info(t('meeting.toast.userLeft', { name }), `leave-${participant.userId}`);
+    };
+
+    socket.on('participant-joined', handleJoined);
+    socket.on('participant-left', handleLeft);
+
+    return () => {
+      socket.off('participant-joined', handleJoined);
+      socket.off('participant-left', handleLeft);
+    };
+  }, [socket, t]);
+};

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -123,6 +123,14 @@
     "status": {
       "active": "ACTIVE",
       "ended": "ENDED"
+    },
+    "toast": {
+      "roomIdCopied": "Room ID copied to clipboard",
+      "userJoined": "{{name}} joined the room",
+      "userLeft": "{{name}} left the room",
+      "joinFailed": "Failed to join meeting. Please try again.",
+      "mediaPermissionDenied": "Camera or microphone access was denied",
+      "webrtcError": "Connection issue with a participant"
     }
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'react-hot-toast';
 import { queryClient } from '@/lib/query';
 import '@/lib/i18n/config';
 import './index.css';
@@ -11,6 +12,25 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <App />
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          style: {
+            borderRadius: '8px',
+            background: '#1f2937',
+            color: '#f3f4f6',
+            fontSize: '14px',
+            padding: '12px 16px',
+            boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -4px rgba(0, 0, 0, 0.2)',
+          },
+          success: {
+            iconTheme: { primary: '#22c55e', secondary: '#f3f4f6' },
+          },
+          error: {
+            iconTheme: { primary: '#ef4444', secondary: '#f3f4f6' },
+          },
+        }}
+      />
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,1 +1,2 @@
 export { cn } from './cn';
+export { showToast } from './toast';

--- a/src/shared/utils/toast.ts
+++ b/src/shared/utils/toast.ts
@@ -1,0 +1,24 @@
+import { createElement } from 'react';
+import toast from 'react-hot-toast';
+import InfoCircleIcon from '@/assets/icons/info-circle.svg?react';
+
+/**
+ * Thin wrapper around react-hot-toast with consistent defaults.
+ *
+ * The optional `id` parameter prevents duplicate toasts — if a toast
+ * with the same id is already visible, the call is a no-op.
+ */
+export const showToast = {
+  success: (message: string, id?: string) => toast.success(message, { id, duration: 3000 }),
+
+  error: (message: string, id?: string) => toast.error(message, { id, duration: 4000 }),
+
+  info: (message: string, id?: string) =>
+    toast(message, {
+      id,
+      duration: 3000,
+      icon: createElement(InfoCircleIcon, {
+        className: 'w-5 h-5 text-blue-400',
+      }),
+    }),
+};


### PR DESCRIPTION
## Description
- Add toast notification system to the meeting experience
- Integrate  for user feedback on join, leave, errors, and actions
- Add  hook for participant join/leave notifications
- Show toasts for media errors, WebRTC negotiation errors, and room actions
- Affected modules: meeting components, hooks, shared utils

## Test plan
- [ ] Join a meeting and verify join/leave toasts appear
- [ ] Trigger media or WebRTC errors and verify error toasts
- [ ] Copy meeting ID and verify success toast
- [ ] Observe participant join/leave notifications
