### PR TITLE
feat(ui): add animated global loading screen with lazy routing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy FE to S3 + CloudFront
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-southeast-1
+
+      - name: Upload to S3
+        run: |
+          aws s3 sync dist/ s3://we-meet-frontend-prod-905418376926-ap-southeast-1-an --delete
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E222XRG9MYMR4C \
+            --paths "/*"

--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;800;900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
     <title>we-meet-client</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.90.17",
     "axios": "^1.13.2",
     "i18next": "^25.8.1",
+    "motion": "^12.34.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hot-toast": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       i18next:
         specifier: ^25.8.1
         version: 25.8.1(typescript@5.9.3)
+      motion:
+        specifier: ^12.34.5
+        version: 12.34.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.0
         version: 19.2.3
@@ -1290,6 +1293,20 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  framer-motion@12.34.5:
+    resolution: {integrity: sha512-Z2dQ+o7BsfpJI3+u0SQUNCrN+ajCKJen1blC4rCHx1Ta2EOHs+xKJegLT2aaD9iSMbU3OoX+WabQXkloUbZmJQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1589,6 +1606,26 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  motion-dom@12.34.5:
+    resolution: {integrity: sha512-k33CsnxO2K3gBRMUZT+vPmc4Utlb5menKdG0RyVNLtlqRaaJPRWlE9fXl8NTtfZ5z3G8TDvqSu0MENLqSTaHZA==}
+
+  motion-utils@12.29.2:
+    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
+
+  motion@12.34.5:
+    resolution: {integrity: sha512-N06NLJ9IeBHeielRqIvYvjPfXuRdyTxa+9++BgpGa+hY2D7TcMkI6QzV3jaRuv0aZRXgMa7cPy9YcBUBisPzAQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3102,6 +3139,15 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  framer-motion@12.34.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      motion-dom: 12.34.5
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   fsevents@2.3.3:
     optional: true
 
@@ -3351,6 +3397,20 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  motion-dom@12.34.5:
+    dependencies:
+      motion-utils: 12.29.2
+
+  motion-utils@12.29.2: {}
+
+  motion@12.34.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      framer-motion: 12.34.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   ms@2.1.3: {}
 

--- a/src/components/loading/LoadingScreen.tsx
+++ b/src/components/loading/LoadingScreen.tsx
@@ -1,0 +1,383 @@
+import { useEffect, useReducer } from 'react';
+import { motion, AnimatePresence, useReducedMotion, type Variants } from 'motion/react';
+import { useTranslation } from 'react-i18next';
+import ShieldCheckIcon from '@/assets/icons/shield-check.svg?react';
+
+interface LoadingScreenProps {
+  isFinished?: boolean;
+  onExitComplete?: () => void;
+}
+
+const cssKeyframes = `
+@keyframes ls-orbit {
+  0% { transform: rotate(0deg) translateX(80px) rotate(0deg); opacity: 0; }
+  10% { opacity: 1; }
+  90% { opacity: 1; }
+  100% { transform: rotate(360deg) translateX(80px) rotate(-360deg); opacity: 0; }
+}
+@keyframes ls-particle-drift {
+  0% { transform: translate(0, 0); opacity: 0; }
+  20% { opacity: 0.4; }
+  80% { opacity: 0.4; }
+  100% { transform: translate(100px, -100px); opacity: 0; }
+}
+`;
+
+const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.6, ease: 'easeOut' } },
+  exit: { opacity: 0, transition: { duration: 0.4, ease: 'easeInOut' } },
+};
+
+const STATUS_KEYS = [
+  'common.loadingStatus.connecting',
+  'common.loadingStatus.syncing',
+  'common.loadingStatus.almostReady',
+] as const;
+
+const CYCLE_MS = 2800;
+
+const NOISE_URI =
+  "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E\")";
+
+const SHIMMER_GRADIENT =
+  'linear-gradient(90deg, #6764f2 0%, #bcbbfd 25%, #6764f2 50%, #bcbbfd 75%, #6764f2 100%)';
+
+const PARTICLES = [
+  { top: '20%', left: '30%', size: 'w-1.5 h-1.5', dur: '10s', delay: '0s' },
+  { top: '60%', left: '20%', size: 'w-1 h-1', dur: '12s', delay: '-3s' },
+  { top: '40%', left: '80%', size: 'w-2 h-2', dur: '15s', delay: '-5s' },
+  { top: '80%', left: '60%', size: 'w-1.5 h-1.5', dur: '9s', delay: '-2s' },
+] as const;
+
+function BackgroundLayer() {
+  return (
+    <div className="fixed inset-0 z-0 pointer-events-none overflow-hidden" aria-hidden="true">
+      <motion.div
+        className="absolute -top-1/4 -left-1/4 w-[150%] h-[150%]"
+        style={{
+          background:
+            'radial-gradient(circle at center, rgba(103,100,242,0.12) 0%, transparent 60%)',
+        }}
+        animate={{
+          x: ['-5%', '5%', '-5%'],
+          y: ['-5%', '5%', '-5%'],
+          scale: [1, 1.1, 1],
+          opacity: [0.3, 0.6, 0.3],
+        }}
+        transition={{ duration: 15, repeat: Infinity, ease: 'easeInOut' }}
+      />
+
+      <motion.div
+        className="absolute -bottom-1/4 -right-1/4 w-[150%] h-[150%]"
+        style={{
+          background:
+            'radial-gradient(circle at center, rgba(188,187,253,0.1) 0%, transparent 60%)',
+        }}
+        animate={{
+          x: ['5%', '-5%', '5%'],
+          y: ['5%', '-5%', '5%'],
+          scale: [1.1, 1, 1.1],
+          opacity: [0.6, 0.3, 0.6],
+        }}
+        transition={{ duration: 15, repeat: Infinity, ease: 'easeInOut' }}
+      />
+
+      <div
+        className="absolute inset-0 opacity-30"
+        style={{
+          backgroundImage: 'radial-gradient(#6764f215 1.5px, transparent 1.5px)',
+          backgroundSize: '48px 48px',
+        }}
+      />
+
+      <div
+        className="absolute inset-0 opacity-[0.03] mix-blend-overlay"
+        style={{ backgroundImage: NOISE_URI }}
+      />
+    </div>
+  );
+}
+
+function MidLayer() {
+  return (
+    <div className="fixed inset-0 z-10 pointer-events-none overflow-hidden" aria-hidden="true">
+      {PARTICLES.map((p, i) => (
+        <div
+          key={i}
+          className={`absolute ${p.size} rounded-full opacity-0`}
+          style={{
+            top: p.top,
+            left: p.left,
+            background: '#6764f2',
+            filter: 'blur(2px)',
+            pointerEvents: 'none',
+            animation: `ls-particle-drift ${p.dur} linear infinite`,
+            animationDelay: p.delay,
+          }}
+        />
+      ))}
+
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-full max-w-4xl opacity-10">
+        <svg
+          className="w-full h-full"
+          fill="none"
+          viewBox="0 0 800 800"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.circle
+            cx="400"
+            cy="400"
+            r="300"
+            stroke="#6764f2"
+            strokeDasharray="10 20"
+            strokeWidth="0.5"
+            animate={{ rotate: 360 }}
+            transition={{ duration: 4, repeat: Infinity, ease: 'linear' }}
+            style={{ transformOrigin: 'center' }}
+          />
+          <motion.circle
+            cx="400"
+            cy="400"
+            r="220"
+            stroke="#6764f2"
+            strokeDasharray="5 15"
+            strokeWidth="1"
+            animate={{ rotate: -360 }}
+            transition={{ duration: 10, repeat: Infinity, ease: 'linear' }}
+            style={{ transformOrigin: 'center' }}
+          />
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+function LogoArea() {
+  const { t } = useTranslation();
+  const appNameParts = t('common.appName').split(' ');
+  const prefix = appNameParts[0];
+  const suffix = appNameParts.slice(1).join(' ');
+
+  return (
+    <div className="flex flex-col items-center gap-6 scale-110">
+      <div className="relative flex items-center justify-center h-48 w-48">
+        <motion.div
+          className="absolute w-48 h-48 bg-primary/25 rounded-full"
+          animate={{
+            scale: [1.2, 1.8, 1.2],
+            opacity: [0.3, 0.5, 0.3],
+            filter: ['blur(50px)', 'blur(70px)', 'blur(50px)'],
+          }}
+          transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut' }}
+        />
+
+        <motion.div
+          className="absolute w-44 h-44 rounded-full border-[1.5px] border-transparent border-t-primary/40 border-r-primary/10"
+          animate={{ rotate: 360 }}
+          transition={{ duration: 4, repeat: Infinity, ease: 'linear' }}
+        />
+
+        <div className="absolute w-40 h-40">
+          <div
+            className="absolute top-0 left-1/2 -ml-1 w-2 h-2 bg-primary rounded-full"
+            style={{
+              animation: 'ls-orbit 3s cubic-bezier(0.4, 0, 0.2, 1) infinite',
+            }}
+          />
+          <div
+            className="absolute top-0 left-1/2 -ml-1 w-2 h-2 bg-primary/40 rounded-full"
+            style={{
+              animation: 'ls-orbit 3s cubic-bezier(0.4, 0, 0.2, 1) infinite',
+              animationDelay: '1.5s',
+            }}
+          />
+        </div>
+
+        <motion.div
+          className="relative select-none"
+          animate={{ y: [-8, 8, -8], scale: [0.98, 1.02, 0.98] }}
+          transition={{
+            duration: 6,
+            repeat: Infinity,
+            ease: [0.45, 0, 0.55, 1],
+          }}
+        >
+          <span
+            className="material-symbols-outlined text-primary text-9xl"
+            style={{ fontVariationSettings: "'FILL' 1" }}
+          >
+            video_chat
+          </span>
+        </motion.div>
+      </div>
+
+      <motion.h1
+        className="text-5xl font-black tracking-tight"
+        initial={{ y: 15, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1], delay: 0.4 }}
+      >
+        <span className="text-slate-900">{prefix}</span>
+        <motion.span
+          style={{
+            background: SHIMMER_GRADIENT,
+            backgroundSize: '200% auto',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+          }}
+          animate={{ backgroundPosition: ['-200% center', '200% center'] }}
+          transition={{ duration: 5, repeat: Infinity, ease: 'linear' }}
+        >
+          {suffix}
+        </motion.span>
+      </motion.h1>
+    </div>
+  );
+}
+
+function TextSection() {
+  const { t } = useTranslation();
+  const [index, next] = useReducer((s: number) => (s + 1) % STATUS_KEYS.length, 0);
+
+  useEffect(() => {
+    const id = setInterval(next, CYCLE_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <motion.div
+      className="text-center space-y-3"
+      initial={{ y: 15, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1], delay: 0.4 }}
+    >
+      <div className="flex flex-col items-center">
+        <div className="h-5 overflow-hidden">
+          <AnimatePresence mode="wait">
+            <motion.p
+              key={index}
+              className="text-sm font-medium text-slate-500/80 tracking-wide"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.3 }}
+            >
+              {t(STATUS_KEYS[index])}
+            </motion.p>
+          </AnimatePresence>
+        </div>
+
+        <div className="mt-4 flex space-x-1">
+          <div
+            className="w-1 h-1 bg-primary/30 rounded-full animate-bounce"
+            style={{ animationDelay: '0.1s' }}
+          />
+          <div
+            className="w-1 h-1 bg-primary/30 rounded-full animate-bounce"
+            style={{ animationDelay: '0.2s' }}
+          />
+          <div
+            className="w-1 h-1 bg-primary/30 rounded-full animate-bounce"
+            style={{ animationDelay: '0.3s' }}
+          />
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function FooterBadge() {
+  const { t } = useTranslation();
+
+  return (
+    <footer className="fixed bottom-12 w-full text-center z-30 opacity-40">
+      <div className="inline-flex items-center space-x-2 px-4 py-2 bg-white/20 backdrop-blur-md rounded-full border border-white/30">
+        <span className="material-symbols-outlined text-[14px] text-primary">lock</span>
+        <p className="text-[10px] font-bold uppercase tracking-[0.25em] text-slate-500">
+          {t('common.loadingStatus.secure')}
+        </p>
+      </div>
+    </footer>
+  );
+}
+
+function ReducedMotionFallback() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-[#f8f9fa] font-['Inter']">
+      <main className="relative flex flex-col items-center justify-center max-w-lg w-full px-8">
+        <div className="w-full flex flex-col items-center justify-center space-y-8">
+          <div className="relative flex items-center justify-center">
+            <span
+              className="material-symbols-outlined text-primary text-9xl select-none"
+              style={{ fontVariationSettings: "'FILL' 1" }}
+            >
+              video_chat
+            </span>
+          </div>
+          <div className="text-center space-y-3">
+            <h1 className="text-5xl font-black tracking-tight text-slate-900">
+              {t('common.appName')}
+            </h1>
+            <p className="text-sm font-medium text-slate-500/80 tracking-wide">
+              {t('common.loadingStatus.connecting')}
+            </p>
+          </div>
+        </div>
+      </main>
+      <footer className="fixed bottom-12 w-full text-center opacity-40">
+        <div className="inline-flex items-center space-x-2 px-4 py-2 bg-white/20 backdrop-blur-md rounded-full border border-white/30">
+          <ShieldCheckIcon className="w-3.5 h-3.5 text-primary" />
+          <p className="text-[10px] font-bold uppercase tracking-[0.25em] text-slate-500">
+            {t('common.loadingStatus.secure')}
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+const LoadingScreen = ({ isFinished = false, onExitComplete }: LoadingScreenProps) => {
+  const prefersReduced = useReducedMotion();
+  if (prefersReduced) {
+    if (isFinished) return null;
+    return <ReducedMotionFallback />;
+  }
+
+  return (
+    <AnimatePresence onExitComplete={onExitComplete}>
+      {!isFinished && (
+        <motion.div
+          key="loading-screen"
+          variants={containerVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-[#f8f9fa] font-['Inter']"
+          role="status"
+          aria-label="Loading"
+          aria-live="polite"
+        >
+          <style>{cssKeyframes}</style>
+
+          <BackgroundLayer />
+
+          <MidLayer />
+
+          <main className="relative z-20 flex flex-col items-center justify-center max-w-lg w-full px-8">
+            <div className="w-full flex flex-col items-center justify-center space-y-8">
+              <LogoArea />
+              <TextSection />
+            </div>
+          </main>
+
+          <FooterBadge />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default LoadingScreen;

--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -1,7 +1,12 @@
+import { Suspense, lazy } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
-import { LoginPage, DashboardPage, ProtectedRoute } from '@/features/auth';
-import { MeetingPage } from '@/features/meeting';
-import { StartMeetingPage } from '@/features/meeting/components/startMeetingPage';
+import LoadingScreen from '@/components/loading/LoadingScreen';
+
+const LoginPage = lazy(() => import('@/features/auth/components/loginPage'));
+const DashboardPage = lazy(() => import('@/features/auth/components/dashboardPage'));
+const ProtectedRoute = lazy(() => import('@/features/auth/components/protectedRoute'));
+const StartMeetingPage = lazy(() => import('@/features/meeting/components/startMeetingPage'));
+const MeetingPage = lazy(() => import('@/features/meeting/components/MeetingPage'));
 
 export const router = createBrowserRouter([
   {
@@ -10,22 +15,42 @@ export const router = createBrowserRouter([
   },
   {
     path: '/login',
-    element: <LoginPage />,
+    element: (
+      <Suspense fallback={<LoadingScreen />}>
+        <LoginPage />
+      </Suspense>
+    ),
   },
   {
-    element: <ProtectedRoute />,
+    element: (
+      <Suspense fallback={<LoadingScreen />}>
+        <ProtectedRoute />
+      </Suspense>
+    ),
     children: [
       {
         path: '/dashboard',
-        element: <DashboardPage />,
+        element: (
+          <Suspense fallback={<LoadingScreen />}>
+            <DashboardPage />
+          </Suspense>
+        ),
       },
       {
         path: '/meetings/start',
-        element: <StartMeetingPage />,
+        element: (
+          <Suspense fallback={<LoadingScreen />}>
+            <StartMeetingPage />
+          </Suspense>
+        ),
       },
       {
         path: '/meetings/:id',
-        element: <MeetingPage />,
+        element: (
+          <Suspense fallback={<LoadingScreen />}>
+            <MeetingPage />
+          </Suspense>
+        ),
       },
     ],
   },

--- a/src/features/auth/components/dashboardPage.tsx
+++ b/src/features/auth/components/dashboardPage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../hooks/useAuth';
 import { Heading, Text, Button } from '@/components/ui';
 import { Header } from '@/components/layout/Header';
 
-export const DashboardPage = () => {
+const DashboardPage = () => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -61,3 +61,5 @@ export const DashboardPage = () => {
     </div>
   );
 };
+
+export default DashboardPage;

--- a/src/features/auth/components/loginPage.tsx
+++ b/src/features/auth/components/loginPage.tsx
@@ -9,7 +9,7 @@ import EyeOffIcon from '@/assets/icons/eye-off.svg?react';
 import ArrowRightIcon from '@/assets/icons/arrow-right.svg?react';
 import SpinnerIcon from '@/assets/icons/spinner.svg?react';
 
-export const LoginPage = () => {
+const LoginPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { login, isLoading: authLoading } = useAuth();
@@ -161,3 +161,5 @@ export const LoginPage = () => {
     </div>
   );
 };
+
+export default LoginPage;

--- a/src/features/auth/components/protectedRoute.tsx
+++ b/src/features/auth/components/protectedRoute.tsx
@@ -8,7 +8,7 @@ interface ProtectedRouteProps {
   children?: React.ReactNode;
 }
 
-export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   const { isAuthenticated, isLoading } = useAuth();
   const { t } = useTranslation();
 
@@ -29,3 +29,5 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
 
   return children ? <>{children}</> : <Outlet />;
 };
+
+export default ProtectedRoute;

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,7 +1,6 @@
-// Components
-export { LoginPage } from './components/loginPage';
-export { DashboardPage } from './components/dashboardPage';
-export { ProtectedRoute } from './components/protectedRoute';
+export { default as LoginPage } from './components/loginPage';
+export { default as DashboardPage } from './components/dashboardPage';
+export { default as ProtectedRoute } from './components/protectedRoute';
 
 export { AuthProvider } from './context/authContext';
 export { useAuth } from './hooks/useAuth';

--- a/src/features/meeting/components/MeetingPage.tsx
+++ b/src/features/meeting/components/MeetingPage.tsx
@@ -26,7 +26,7 @@ import { LocalVideoPreview } from './LocalVideoPreview';
 import { ParticipantList } from './ParticipantList';
 import { MeetingPhase, MeetingPhaseFlags } from '@/shared/constants/meeting';
 
-export const MeetingPage = () => {
+const MeetingPage = () => {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -524,3 +524,5 @@ export const MeetingPage = () => {
     </div>
   );
 };
+
+export default MeetingPage;

--- a/src/features/meeting/components/startMeetingPage.tsx
+++ b/src/features/meeting/components/startMeetingPage.tsx
@@ -19,7 +19,6 @@ import ShieldCheckIcon from '@/assets/icons/shield-check.svg?react';
 import { meetingsApi } from '../services/meetingService';
 import type { ApiError } from '../types/meeting.types';
 
-// Hoisted static JSX — avoids re-creation on every render (rendering-hoist-jsx)
 const backgroundDecoration = (
   <div className="fixed inset-0 -z-10 pointer-events-none overflow-hidden">
     <div className="absolute -top-[10%] -left-[10%] w-1/2 h-1/2 bg-primary/5 blur-[150px] rounded-full" />
@@ -27,7 +26,7 @@ const backgroundDecoration = (
   </div>
 );
 
-export const StartMeetingPage = () => {
+const StartMeetingPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { user, logout } = useAuth();
@@ -285,3 +284,5 @@ export const StartMeetingPage = () => {
     </div>
   );
 };
+
+export default StartMeetingPage;

--- a/src/features/meeting/index.ts
+++ b/src/features/meeting/index.ts
@@ -1,4 +1,4 @@
-export { MeetingPage } from './components/MeetingPage';
+export { default as MeetingPage } from './components/MeetingPage';
 export { ParticipantList } from './components/ParticipantList';
 export { LocalVideoPreview } from './components/LocalVideoPreview';
 export { MediaControls } from './components/MediaControls';

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -4,7 +4,13 @@
     "loading": "Loading...",
     "error": "An error occurred",
     "cancel": "Cancel",
-    "logout": "Logout"
+    "logout": "Logout",
+    "loadingStatus": {
+      "connecting": "Establishing secure connection…",
+      "syncing": "Syncing your session…",
+      "almostReady": "Almost ready…",
+      "secure": "Encrypted & Secure Ecosystem"
+    }
   },
   "login": {
     "title": "Log in to VideoMeet",


### PR DESCRIPTION
## Description
- Added pixel-perfect animated LoadingScreen component replicating Stitch Immersive Loading Experience design
- 3-layer animated background: radial glows, dot grid, SVG noise; orbiting dots, rotating ring, floating logo, shimmer AppName
- Installed motion (Framer Motion v12) for animations; CSS keyframes for compound-transform orbit effect
- Added Material Symbols Outlined and Inter fonts to index.html via Google Fonts
- Converted all routes to React.lazy + Suspense with LoadingScreen as universal fallback
- Added i18n keys for cycling status messages (connecting, syncing, almostReady, secure)
- Supports prefers-reduced-motion with static fallback renderer
- Fixed StartMeetingPage and feature index exports to use export default pattern

## Test plan
- [ ] Loading screen appears on initial chunk load
- [ ] Hard refresh each route (/login, /dashboard, /meetings/start, /meetings/:id) shows loading screen
- [ ] AppName appears directly below the rotating icon circle
- [ ] Shimmer gradient animates on second word of app name
- [ ] With prefers-reduced-motion enabled, static fallback renders without animations
- [ ] Footer badge shows Encrypted and Secure Ecosystem at bottom
